### PR TITLE
server-node: serve client/fcaptcha.js at /fcaptcha.js by default

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -65,7 +65,9 @@ FCaptcha ships in two halves: an HTTP API (`server-node`, `server-python`, `serv
 
 If you'd rather host the widget on a CDN or edge cache and only run the API from the FCaptcha server, set `FCAPTCHA_SERVE_CLIENT=false` and serve `client/fcaptcha.js` yourself from wherever fits your infrastructure. Point your widget loader at that URL.
 
-The Python and Go servers do not yet serve the widget — track [issue #4](https://github.com/WebDecoy/FCaptcha/issues/4) for parity.
+If you've copied `server-node/` to a location where the sibling `client/` directory isn't present, set `FCAPTCHA_CLIENT_PATH=/absolute/path/to/fcaptcha.js` to override the default lookup.
+
+The Go server (`server-go`) already serves `/fcaptcha.js` via its embedded static directory. The Python server (`server-python`) does not yet — track [issue #4](https://github.com/WebDecoy/FCaptcha/issues/4) for parity.
 
 ---
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -57,6 +57,18 @@ Open `demo/index.html` in your browser to test.
 
 ---
 
+## How the widget reaches the browser
+
+FCaptcha ships in two halves: an HTTP API (`server-node`, `server-python`, `server-go`) and a browser widget (`client/fcaptcha.js`).
+
+**By default, `server-node` serves the widget at `/fcaptcha.js` from the same origin as the API.** Integrators that expose a single `serverUrl` to their clients (and load the widget from `<serverUrl>/fcaptcha.js`) work out of the box. Most consumers want this.
+
+If you'd rather host the widget on a CDN or edge cache and only run the API from the FCaptcha server, set `FCAPTCHA_SERVE_CLIENT=false` and serve `client/fcaptcha.js` yourself from wherever fits your infrastructure. Point your widget loader at that URL.
+
+The Python and Go servers do not yet serve the widget — track [issue #4](https://github.com/WebDecoy/FCaptcha/issues/4) for parity.
+
+---
+
 ## Server Installation
 
 ### Node.js Server

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -21,10 +21,14 @@ const TRUSTED_JA4_HEADERS = detection.getTrustedJA4HeaderNames();
 // Serve the browser widget alongside the API so deployments expose a single
 // origin to integrators (the implicit contract behind <serverUrl>/fcaptcha.js).
 // Set FCAPTCHA_SERVE_CLIENT=false to opt out — useful when hosting the widget
-// on a separate CDN / edge cache.
+// on a separate CDN / edge cache. Set FCAPTCHA_CLIENT_PATH=/abs/path/fcaptcha.js
+// to override the default lookup when server-node is deployed standalone.
+const CLIENT_PATH = process.env.FCAPTCHA_CLIENT_PATH
+  || path.join(__dirname, '..', 'client', 'fcaptcha.js');
+
 if (process.env.FCAPTCHA_SERVE_CLIENT !== 'false') {
   app.get('/fcaptcha.js', (req, res) => {
-    res.sendFile(path.join(__dirname, '..', 'client', 'fcaptcha.js'));
+    res.sendFile(CLIENT_PATH);
   });
 }
 

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -7,6 +7,7 @@
 const express = require('express');
 const cors = require('cors');
 const crypto = require('crypto');
+const path = require('path');
 const detection = require('./detection');
 
 const app = express();
@@ -16,6 +17,16 @@ app.use(express.json());
 const SECRET_KEY = process.env.FCAPTCHA_SECRET || 'dev-secret-change-in-production';
 const PORT = process.env.PORT || 3000;
 const TRUSTED_JA4_HEADERS = detection.getTrustedJA4HeaderNames();
+
+// Serve the browser widget alongside the API so deployments expose a single
+// origin to integrators (the implicit contract behind <serverUrl>/fcaptcha.js).
+// Set FCAPTCHA_SERVE_CLIENT=false to opt out — useful when hosting the widget
+// on a separate CDN / edge cache.
+if (process.env.FCAPTCHA_SERVE_CLIENT !== 'false') {
+  app.get('/fcaptcha.js', (req, res) => {
+    res.sendFile(path.join(__dirname, '..', 'client', 'fcaptcha.js'));
+  });
+}
 
 // =============================================================================
 // In-Memory Storage (Use Redis in production)


### PR DESCRIPTION
Closes #4.

`server-node` doesn't currently serve the browser widget bundle. Integrators that expose a single `serverUrl` to their clients and load the widget from `<serverUrl>/fcaptcha.js` (the implicit contract that matches `server-go`) get a 404. This wires it up at the same origin as the API, with two opt-out switches.

## What this changes

- `server-node/server.js` — register `GET /fcaptcha.js` that `res.sendFile`s `client/fcaptcha.js`. Gated behind `FCAPTCHA_SERVE_CLIENT !== 'false'`.
- `FCAPTCHA_CLIENT_PATH` env override — for cases where `server-node/` is copied somewhere without a sibling `../client/` directory.
- `INSTALLATION.md` — new "How the widget reaches the browser" section explaining the default + the two env vars + the current Python/Go parity status.

Net diff: 2 files, +23/-3.

## Design choices (per the discussion on #4)

- **Opt-out, not opt-in**. Existing consumers depend on the implicit single-origin contract; making the route opt-in would silently break them. `FCAPTCHA_SERVE_CLIENT=false` exits the route registration cleanly when an operator wants to host the widget on a CDN.
- **`res.sendFile` over `express.static`**. Single-file route is cleaner than directory binding for one bundle.
- **`FCAPTCHA_CLIENT_PATH` env var**. Cheap insurance against the `../client/` assumption breaking when `server-node/` is deployed standalone.
- **`server-go` already serves it** (via `main.go:63` + Docker `COPY client/fcaptcha.js ./static/`), so this PR doesn't touch it. `INSTALLATION.md` now reflects that.

## Out of scope

- `server-python` parity. Happy to send as a separate PR with the same shape (`FCAPTCHA_SERVE_CLIENT` opt-out + `FCAPTCHA_CLIENT_PATH` override).

## Verified locally

- Default: `GET /fcaptcha.js` → HTTP 200, 98 KB bundle.
- `FCAPTCHA_SERVE_CLIENT=false`: `GET /fcaptcha.js` → 404 (route not registered).
- `FCAPTCHA_CLIENT_PATH=/tmp/override.js`: `res.sendFile` resolves the override path.
- `/health` and the existing `/api/*` routes unchanged.