### PR TITLE
server-python: serve client/fcaptcha.js at /fcaptcha.js by default

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -147,7 +147,13 @@ gunicorn server:app -w 4 -k uvicorn.workers.UvicornWorker -b 0.0.0.0:3000
 ```bash
 curl http://localhost:3000/health
 # {"status":"ok"}
+
+# The browser widget is served from the same origin by default:
+curl -I http://localhost:3000/fcaptcha.js
+# HTTP/1.1 200 OK
 ```
+
+By default, `server-python` serves `client/fcaptcha.js` at `/fcaptcha.js` so integrators that expose a single `serverUrl` to their clients (and load the widget from `<serverUrl>/fcaptcha.js`) work out of the box. Set `FCAPTCHA_SERVE_CLIENT=false` to opt out (e.g. when hosting the widget on a CDN), or `FCAPTCHA_CLIENT_PATH=/abs/path/to/fcaptcha.js` to override the default lookup when `server-python/` is deployed without the sibling `client/` directory.
 
 ---
 

--- a/server-python/server.py
+++ b/server-python/server.py
@@ -18,6 +18,7 @@ from collections import defaultdict
 
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 app = FastAPI(title="FCaptcha", version="1.0.0")
@@ -30,6 +31,21 @@ app.add_middleware(
 )
 
 SECRET_KEY = os.getenv("FCAPTCHA_SECRET", "dev-secret-change-in-production")
+
+# Serve the browser widget alongside the API so deployments expose a single
+# origin to integrators (the implicit contract behind <serverUrl>/fcaptcha.js).
+# Set FCAPTCHA_SERVE_CLIENT=false to opt out — useful when hosting the widget
+# on a separate CDN / edge cache. Set FCAPTCHA_CLIENT_PATH=/abs/path/fcaptcha.js
+# to override the default lookup when server-python is deployed standalone.
+CLIENT_PATH = os.getenv(
+    "FCAPTCHA_CLIENT_PATH",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "client", "fcaptcha.js"),
+)
+
+if os.getenv("FCAPTCHA_SERVE_CLIENT", "true").lower() != "false":
+    @app.get("/fcaptcha.js")
+    async def fcaptcha_js():
+        return FileResponse(CLIENT_PATH, media_type="application/javascript")
 
 
 # =============================================================================


### PR DESCRIPTION
Refs #4. Companion follow-up to #5 — same shape applied to `server-python`.

`server-go` already serves `/fcaptcha.js` (via its embedded static dir) and #5 wires it up for `server-node`. This PR closes the third gap: `server-python` now serves the browser widget at the same origin as the API, with the same two opt-outs as the server-node PR.

## What this changes

- `server-python/server.py` — register `GET /fcaptcha.js` returning a FastAPI `FileResponse` for `client/fcaptcha.js`. Gated behind `FCAPTCHA_SERVE_CLIENT != 'false'` (case-insensitive).
- `FCAPTCHA_CLIENT_PATH` env override — for cases where `server-python/` is copied somewhere without a sibling `../client/` directory.
- `INSTALLATION.md` — extend the existing **Python Server → Step 5: Verify** section with the `/fcaptcha.js` check and document the two env vars.

Net diff: 2 files, +22/-0.

## Design choices

Mirrors #5 deliberately so the Python and Node behaviour are identical from an operator's perspective:

- **Same env-var names**: `FCAPTCHA_SERVE_CLIENT=false` opt-out, `FCAPTCHA_CLIENT_PATH=/abs/path/fcaptcha.js` override.
- **Opt-out, not opt-in** — same single-origin contract reasoning.
- **`FileResponse` over a `StaticFiles` mount** — single-file shape mirrors `res.sendFile` in #5 (cleaner than directory binding for one bundle).
- **`media_type="application/javascript"`** explicitly set so the response sends the right `Content-Type` regardless of which platform's mime-type lookup table is in use.

## Independence from #5

This PR does not touch `server-node` or `INSTALLATION.md`'s Node section, so it can land before, after, or alongside #5 without conflict. If both merge, we have full Node/Python parity; if only one merges, the other server still has the gap until its PR lands.

## Verified locally

```python
# default lookup
CLIENT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "client", "fcaptcha.js")
# → resolves to client/fcaptcha.js (98 KB, exists)

# opt-out gate
os.getenv("FCAPTCHA_SERVE_CLIENT", "true").lower() != "false"
# → True (default), False ("false"), False ("FALSE")

# override
FCAPTCHA_CLIENT_PATH=/tmp/override.js  # → CLIENT_PATH = "/tmp/override.js"
```

`ast.parse` succeeds on the modified `server.py` (no syntax errors).