### PR TITLE
chore(server-go): gate pprof debug server behind FCAPTCHA_PPROF

### DIFF
--- a/server-go/main.go
+++ b/server-go/main.go
@@ -49,6 +49,17 @@ func resolveClientPath() string {
 	return ""
 }
 
+// pprofEnabled reports whether the optional pprof debug server should start,
+// based on FCAPTCHA_PPROF (1/true/yes/on, case-insensitive). Off by default.
+func pprofEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("FCAPTCHA_PPROF"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
 func main() {
 	// Configuration
 	secretKey := os.Getenv("FCAPTCHA_SECRET")
@@ -126,12 +137,21 @@ func main() {
 		IdleTimeout:  60 * time.Second,
 	}
 
-	// pprof debug server on localhost:3001 (not exposed externally)
-	go func() {
-		if err := http.ListenAndServe("127.0.0.1:3001", nil); err != nil {
-			log.Printf("pprof server error: %v", err)
+	// Optional pprof debug server, off by default. Enable with FCAPTCHA_PPROF=1
+	// (or true/yes/on). Binds to loopback unless FCAPTCHA_PPROF_ADDR overrides —
+	// keep it loopback-only, the pprof endpoints expose memory/goroutine state.
+	if pprofEnabled() {
+		pprofAddr := os.Getenv("FCAPTCHA_PPROF_ADDR")
+		if pprofAddr == "" {
+			pprofAddr = "127.0.0.1:3001"
 		}
-	}()
+		go func() {
+			log.Printf("pprof debug server listening on %s", pprofAddr)
+			if err := http.ListenAndServe(pprofAddr, nil); err != nil {
+				log.Printf("pprof server error: %v", err)
+			}
+		}()
+	}
 
 	// Graceful shutdown
 	go func() {


### PR DESCRIPTION
## What

Makes the Go pprof debug server **opt-in** instead of always-on.

PR #7 added a pprof listener on \`127.0.0.1:3001\` that started unconditionally — it was a diagnosis artifact left in while debugging the reverse-DNS blocking issue. This gates it behind an env var.

## Changes

- pprof server only starts when \`FCAPTCHA_PPROF\` is set to \`1\`/\`true\`/\`yes\`/\`on\` (case-insensitive). **Off by default.**
- Address configurable via \`FCAPTCHA_PPROF_ADDR\` (defaults to \`127.0.0.1:3001\`). Keep it loopback-only — pprof exposes memory/goroutine state.
- Logs a line when it starts, so it's never silently listening.

The \`net/http/pprof\` blank import is retained; it only registers handlers on \`DefaultServeMux\`, which the chi router never serves — so the public port (3000) is unaffected whether or not pprof is enabled.

## Verification

- \`go build\`, \`go vet\`, \`go test ./...\` all pass.
- Runtime: with the var unset, \`:3001\` refuses connections; with \`FCAPTCHA_PPROF=1\`, \`/debug/pprof/\` returns 200 and logs \`pprof debug server listening on 127.0.0.1:3001\`.

Follow-up to #7.