### PR TITLE
feat(detection): input-event forensics + LLM think-time cadence (PRD phase 2)

### DIFF
--- a/client/fcaptcha.js
+++ b/client/fcaptcha.js
@@ -40,10 +40,38 @@
       this.lastMouseTime = null;
       this.lastVelocity = null;
       this.eventDeltas = [];
+
+      // --- Input-event forensics (AI-agent detection, PRD phase 2) ---
+      // Cross-input activity timeline for think-time cadence.
+      this._lastActivityT = null;
+      this._cadenceGaps = [];
+      this._teleportClicks = 0;
+      // Coalesced pointermove batches: real mice coalesce multiple hardware
+      // samples per frame; CDP-injected moves produce single-entry batches.
+      this._coalescedSamples = 0;
+      this._coalescedEmpty = 0;
+      this._coalescedSum = 0;
+      this._coalescedMax = 0;
+      // movementX/Y vs position-delta coherence (synthetic input is incoherent).
+      this._ptrLastX = null;
+      this._ptrLastY = null;
+      this._ptrMoveSamples = 0;
+      this._ptrMoveZero = 0;
+    }
+
+    // Record any user-input event on a single timeline so the server can spot
+    // the agent act -> screenshot -> think (dead air) -> act loop.
+    _markActivity(now) {
+      if (this._lastActivityT !== null) {
+        this._cadenceGaps.push(now - this._lastActivityT);
+        if (this._cadenceGaps.length > 1000) this._cadenceGaps.shift();
+      }
+      this._lastActivityT = now;
     }
 
     recordMouseMove(e) {
       const now = performance.now();
+      this._markActivity(now);
       const pos = { x: e.clientX, y: e.clientY, t: now };
 
       this.mousePositions.push(pos);
@@ -80,11 +108,20 @@
     }
 
     recordMouseDown(e) {
+      const now = performance.now();
+      this._markActivity(now);
+      // Teleport click: mousedown landing far from the last observed mouse
+      // position with no intervening movement = injected click (computer-use
+      // agents dispatch a click at coordinates without an approach path).
+      if (this.lastMousePos) {
+        const d = Math.hypot(e.clientX - this.lastMousePos.x, e.clientY - this.lastMousePos.y);
+        if (d > 150) this._teleportClicks++;
+      }
       this.clickData = {
         x: e.clientX,
         y: e.clientY,
         button: e.button,
-        downTime: performance.now()
+        downTime: now
       };
     }
 
@@ -96,23 +133,28 @@
     }
 
     recordScroll(_e) {
+      const now = performance.now();
+      this._markActivity(now);
       this.scrollEvents.push({
         x: window.scrollX,
         y: window.scrollY,
-        t: performance.now()
+        t: now
       });
       if (this.scrollEvents.length > 100) this.scrollEvents.shift();
     }
 
     recordKeyEvent(e) {
+      const now = performance.now();
+      this._markActivity(now);
       this.keyEvents.push({
         type: e.type,
         keyLength: e.key ? e.key.length : 0, // Don't store actual keys
-        t: performance.now()
+        t: now
       });
     }
 
     recordTouch(e) {
+      this._markActivity(performance.now());
       const touches = (e.touches && e.touches.length) ? e.touches : e.changedTouches;
       if (!touches || touches.length === 0) return;
       if (touches.length > 1) this.touchMultiTouchSeen = true;
@@ -135,10 +177,42 @@
     }
 
     recordPointer(e) {
+      const now = performance.now();
+      this._markActivity(now);
+
+      if (e.type === 'pointermove') {
+        // Coalesced-events batch size. Only mouse pointers; touch/pen coalesce
+        // differently and are scored via their own kinematics.
+        if (e.pointerType !== 'touch' && typeof e.getCoalescedEvents === 'function') {
+          let len = 1;
+          try {
+            const coalesced = e.getCoalescedEvents();
+            len = (coalesced && coalesced.length) ? coalesced.length : 1;
+          } catch (_err) { len = 1; }
+          this._coalescedSamples++;
+          if (len <= 1) this._coalescedEmpty++;
+          this._coalescedSum += len;
+          if (len > this._coalescedMax) this._coalescedMax = len;
+        }
+        // movementX/Y should be nonzero whenever the position actually changed.
+        if (e.pointerType !== 'touch' && this._ptrLastX !== null) {
+          const dx = e.clientX - this._ptrLastX;
+          const dy = e.clientY - this._ptrLastY;
+          if (dx !== 0 || dy !== 0) {
+            this._ptrMoveSamples++;
+            const mx = typeof e.movementX === 'number' ? e.movementX : 0;
+            const my = typeof e.movementY === 'number' ? e.movementY : 0;
+            if (mx === 0 && my === 0) this._ptrMoveZero++;
+          }
+        }
+        this._ptrLastX = e.clientX;
+        this._ptrLastY = e.clientY;
+      }
+
       this.pointerPoints.push({
         x: e.clientX,
         y: e.clientY,
-        t: performance.now(),
+        t: now,
         type: e.type,
         pressure: typeof e.pressure === 'number' ? e.pressure : 0,
         tiltX: typeof e.tiltX === 'number' ? e.tiltX : 0,
@@ -147,6 +221,38 @@
         pointerType: e.pointerType || 'unknown'
       });
       if (this.pointerPoints.length > 500) this.pointerPoints.shift();
+    }
+
+    // Aggregate the input-event forensics into a compact object consumed by the
+    // server's detectCDP / detectVisionAI. All thresholds live server-side.
+    _analyzeInputForensics() {
+      const gaps = this._cadenceGaps;
+      let silentGaps = 0;
+      let silentTime = 0;
+      let totalTime = 0;
+      for (const g of gaps) {
+        totalTime += g;
+        if (g > 1500) { silentGaps++; silentTime += g; }
+      }
+      const mean = gaps.length ? totalTime / gaps.length : 0;
+      let variance = 0;
+      if (gaps.length) {
+        variance = gaps.reduce((acc, g) => acc + (g - mean) * (g - mean), 0) / gaps.length;
+      }
+      const gapCV = mean > 0 ? Math.sqrt(variance) / mean : 0;
+      return {
+        coalescedSamples: this._coalescedSamples,
+        coalescedEmptyRatio: this._coalescedSamples ? this._coalescedEmpty / this._coalescedSamples : 0,
+        coalescedAvg: this._coalescedSamples ? this._coalescedSum / this._coalescedSamples : 0,
+        coalescedMax: this._coalescedMax,
+        pointerMoveSamples: this._ptrMoveSamples,
+        pointerMoveZeroRatio: this._ptrMoveSamples ? this._ptrMoveZero / this._ptrMoveSamples : 0,
+        cadenceEvents: gaps.length,
+        cadenceSilentGaps: silentGaps,
+        cadenceGapCV: gapCV,
+        cadenceSilentRatio: totalTime > 0 ? silentTime / totalTime : 0,
+        teleportClicks: this._teleportClicks
+      };
     }
 
     recordFocus(e) {
@@ -247,6 +353,7 @@
         focusEvents: this.focusEvents.length,
         clickData: this.clickData,
         interactionDuration: Date.now() - this.startTime,
+        inputForensics: this._analyzeInputForensics(),
         ...touchAnalysis,
         ...pointerAnalysis
       };
@@ -523,6 +630,7 @@
         scrollEvents: this.scrollEvents.length, keyEvents: this.keyEvents.length,
         touchEvents: this.touchEvents.length, focusEvents: this.focusEvents.length,
         clickData: this.clickData, interactionDuration: Date.now() - this.startTime,
+        inputForensics: this._analyzeInputForensics(),
         ...this._analyzeTouchPoints(this.touchEvents),
         ...this._analyzePointerPoints(this.pointerPoints)
       };
@@ -913,6 +1021,7 @@
         webdriver: this._detectWebdriver(),
         automationFlags: this._getAutomationFlags(),
         cdp: this._detectCDP(),
+        cdpRuntime: this._detectCDPRuntime(),
         playwright: this._detectPlaywright(),
 
         // Browser fingerprints
@@ -1047,6 +1156,28 @@
       } catch (e) {
         return { detected: false, signals: [] };
       }
+    }
+
+    // Detect an attached CDP Runtime/DevTools console consumer. When a client
+    // (DevTools, chrome.debugger, Playwright/Puppeteer over CDP) is attached and
+    // consuming console output, the host eagerly serializes logged objects,
+    // firing accessor traps that never fire for an ordinary visitor. Low
+    // confidence server-side: a developer with DevTools open also trips this.
+    _detectCDPRuntime() {
+      let consoleAttached = false;
+      try {
+        const bait = new Error();
+        Object.defineProperty(bait, 'message', {
+          configurable: true,
+          get() { consoleAttached = true; return ''; }
+        });
+        // debug level is hidden from the visible console by default, so this is
+        // silent for real users while still serialized by an attached consumer.
+        console.debug(bait);
+      } catch (_e) {
+        consoleAttached = false;
+      }
+      return { consoleAttached };
     }
 
     _detectCDP() {

--- a/docs/PRD-ai-agent-detection.md
+++ b/docs/PRD-ai-agent-detection.md
@@ -281,7 +281,15 @@ if cs := getMap(behavioral, "coalescedStats"); cs != nil {
 }
 ```
 
-### 5.2 Pointer internals (pressure / movement coherence)
+### 5.2 Pointer internals (movement coherence)
+
+> **Implementation note (shipped in Phase 2):** the original draft below used
+> `pressure` constancy as a sub-signal. That was dropped — a real mouse hovering
+> (moving without a button held) reports `pressure === 0` on *every* move, so a
+> constant-pressure check false-positives on all mouse users. The shipped signal
+> keeps only **movement/position coherence**: the fraction of position-changing
+> moves where `movementX === 0 && movementY === 0` (`pointerMoveZeroRatio`),
+> fired conservatively (`>= 20` samples, ratio `> 0.9`, low confidence).
 
 ```javascript
 // client/fcaptcha.js — sample on pointermove/pointerdown
@@ -670,8 +678,8 @@ func (e *ScoringEngine) detectCorrelatedAutomation(fp string) []DetectionResult 
 
 | Phase | Scope | Effort | Risk |
 |---|---|---|---|
-| **P1** | §4 declared UAs + IP/ASN via enrichment; new category + policy knob | ~0.5 day | very low |
-| **P2** | §5 coalesced events + pointer internals + CDP side-effect; §6 teleport + cadence | ~2–3 days | medium (FP tuning) |
+| **P1** ✅ | §4 declared UAs (shipped v1.11.0); IP/ASN via enrichment + policy knob still pending | ~0.5 day | very low |
+| **P2** ✅ | §5 coalesced events + movement coherence + CDP side-effect; §6 teleport + cadence + programmatic fill | ~2–3 days | medium (FP tuning) |
 | **P3** | §7 software-GPU + hosted composite + client-hint coherence | ~1–2 days | low |
 | **P4** | §4.3 Web Bot Auth **signature verification** (JWKS fetch/cache) | ~2 days | low |
 | **P5** | §8 a11y honeypots (behind a flag; heavy FP testing first) | ~1 day | medium (a11y FP) |

--- a/server-go/detection.go
+++ b/server-go/detection.go
@@ -1081,6 +1081,19 @@ func (e *ScoringEngine) AnalyzeFormInteraction(formAnalysis map[string]interface
 			avgInterval := getFloat(stats, "avgKeyInterval")
 			intervalVariance := getFloat(stats, "keyIntervalVariance")
 			keydownUpRatio := getFloat(stats, "keydownUpRatio")
+			contentLength := int(getFloat(stats, "contentLength"))
+
+			// Programmatic fill: meaningful content appeared with zero keystrokes
+			// and zero pastes (e.g. Playwright fill() / element.value=). The
+			// length gate keeps this off browser autofill of short fields.
+			if contentLength > 8 && keyCount == 0 && pasteCount == 0 {
+				detections = append(detections, DetectionResult{
+					Category:   CategoryAutomation,
+					Score:      0.8,
+					Confidence: 0.75,
+					Reason:     fmt.Sprintf("Textarea %q filled programmatically (%d chars, no keystrokes or paste)", fieldId, contentLength),
+				})
+			}
 
 			// Check for paste-heavy input
 			if pasteCount > 0 && keyCount < 5 {

--- a/server-go/scoring.go
+++ b/server-go/scoring.go
@@ -780,6 +780,41 @@ func (e *ScoringEngine) detectVisionAI(signals map[string]interface{}) []Detecti
 		})
 	}
 
+	// Input-event forensics: teleport clicks and agent think-time cadence.
+	if fcs := getMap(behavioral, "inputForensics"); fcs != nil {
+		// A click dispatched at coordinates with no approach trajectory.
+		teleports := getFloat(fcs, "teleportClicks")
+		if teleports >= 1 && !isTouchUser {
+			results = append(results, DetectionResult{
+				Category:   CategoryVisionAI,
+				Score:      0.7,
+				Confidence: 0.7,
+				Reason:     fmt.Sprintf("Click injected with no pointer trajectory (%d teleport clicks)", int(teleports)),
+				Details:    map[string]interface{}{"teleportClicks": teleports},
+			})
+		}
+		// Bursts of activity separated by multi-second perfect silence — the
+		// agent act -> screenshot -> inference loop. Low confidence (slow humans
+		// idle too); requires silence to dominate the interaction. Keyboard-only
+		// users are exempt (their cadence is naturally bursty).
+		if !isKeyboardUser &&
+			getFloat(fcs, "cadenceEvents") >= 12 &&
+			getFloat(fcs, "cadenceSilentGaps") >= 3 &&
+			getFloat(fcs, "cadenceGapCV") > 2.5 &&
+			getFloat(fcs, "cadenceSilentRatio") > 0.6 {
+			results = append(results, DetectionResult{
+				Category:   CategoryVisionAI,
+				Score:      0.6,
+				Confidence: 0.5,
+				Reason:     "Interaction cadence matches agent act/think loop (bursts + dead air)",
+				Details: map[string]interface{}{
+					"silentGaps": getFloat(fcs, "cadenceSilentGaps"),
+					"gapCV":      getFloat(fcs, "cadenceGapCV"),
+				},
+			})
+		}
+	}
+
 	return results
 }
 
@@ -971,6 +1006,47 @@ func (e *ScoringEngine) detectCDP(signals map[string]interface{}) []DetectionRes
 	results := make([]DetectionResult, 0)
 
 	env := getMap(signals, "environmental")
+
+	// Input-event forensics: catch CDP-injected input that reports isTrusted:true
+	// and so evades the global-based checks below. Touch users are exempt — they
+	// don't generate the mouse-pointer batches these signals rely on.
+	behavioral := getMap(signals, "behavioral")
+	isTouchUser := getFloat(behavioral, "touchEvents") >= 3
+	if fcs := getMap(behavioral, "inputForensics"); fcs != nil && !isTouchUser {
+		// Real mice coalesce several hardware samples per animation frame; a
+		// stream of pointermoves that NEVER coalesced is synthetic injection.
+		if getFloat(fcs, "coalescedSamples") >= 20 && getFloat(fcs, "coalescedMax") <= 1 {
+			results = append(results, DetectionResult{
+				Category:   CategoryCDP,
+				Score:      0.8,
+				Confidence: 0.6,
+				Reason:     "Pointer moves never coalesced across many samples (synthetic/CDP input)",
+				Details:    map[string]interface{}{"coalescedSamples": getFloat(fcs, "coalescedSamples")},
+			})
+		}
+		// movementX/Y incoherent with actual position deltas across most moves.
+		if getFloat(fcs, "pointerMoveSamples") >= 20 && getFloat(fcs, "pointerMoveZeroRatio") > 0.9 {
+			results = append(results, DetectionResult{
+				Category:   CategoryCDP,
+				Score:      0.6,
+				Confidence: 0.5,
+				Reason:     "Pointer movement deltas incoherent with position (synthetic input)",
+				Details:    map[string]interface{}{"pointerMoveZeroRatio": getFloat(fcs, "pointerMoveZeroRatio")},
+			})
+		}
+	}
+
+	// CDP Runtime/DevTools console consumer attached. Low confidence: a developer
+	// with DevTools open also trips this, so it contributes rather than blocks.
+	if cdpRuntime := getMap(env, "cdpRuntime"); getBool(cdpRuntime, "consoleAttached") {
+		results = append(results, DetectionResult{
+			Category:   CategoryCDP,
+			Score:      0.6,
+			Confidence: 0.5,
+			Reason:     "CDP/DevTools console consumer attached (automation protocol or open DevTools)",
+		})
+	}
+
 	cdp := getMap(env, "cdp")
 
 	detected := getBool(cdp, "detected")

--- a/server-go/scoring_test.go
+++ b/server-go/scoring_test.go
@@ -274,3 +274,155 @@ func TestWeightsSumToOne(t *testing.T) {
 		t.Fatalf("category weights must sum to 1.0, got %.6f", sum)
 	}
 }
+
+// hasReasonContaining reports whether any detection's Reason contains sub.
+func hasReasonContaining(results []DetectionResult, sub string) bool {
+	for _, r := range results {
+		if strings.Contains(r.Reason, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDetectCDP_InputForensics covers the phase-2 synthetic-input signals:
+// coalesced-event absence, movement incoherence, and an attached CDP console.
+func TestDetectCDP_InputForensics(t *testing.T) {
+	e := NewScoringEngine("test-secret")
+
+	// Synthetic: 30 pointermoves that never coalesced + incoherent movement.
+	synthetic := map[string]interface{}{
+		"behavioral": map[string]interface{}{
+			"touchEvents": 0.0,
+			"inputForensics": map[string]interface{}{
+				"coalescedSamples":     30.0,
+				"coalescedMax":         1.0,
+				"pointerMoveSamples":   30.0,
+				"pointerMoveZeroRatio": 0.95,
+			},
+		},
+		"environmental": map[string]interface{}{
+			"cdpRuntime": map[string]interface{}{"consoleAttached": true},
+		},
+	}
+	got := e.detectCDP(synthetic)
+	if !hasReasonContaining(got, "never coalesced") {
+		t.Errorf("expected coalesced-absence detection, got %+v", got)
+	}
+	if !hasReasonContaining(got, "incoherent with position") {
+		t.Errorf("expected movement-incoherence detection, got %+v", got)
+	}
+	if !hasReasonContaining(got, "console consumer attached") {
+		t.Errorf("expected CDP console detection, got %+v", got)
+	}
+
+	// Real mouse: moves coalesced normally, movement coherent, no console.
+	human := map[string]interface{}{
+		"behavioral": map[string]interface{}{
+			"touchEvents": 0.0,
+			"inputForensics": map[string]interface{}{
+				"coalescedSamples":     40.0,
+				"coalescedMax":         6.0,
+				"pointerMoveSamples":   40.0,
+				"pointerMoveZeroRatio": 0.02,
+			},
+		},
+		"environmental": map[string]interface{}{
+			"cdpRuntime": map[string]interface{}{"consoleAttached": false},
+		},
+	}
+	if got := e.detectCDP(human); len(got) != 0 {
+		t.Errorf("expected no CDP detections for human-like input, got %+v", got)
+	}
+
+	// Touch user must be exempt from the mouse-pointer signals.
+	touch := map[string]interface{}{
+		"behavioral": map[string]interface{}{
+			"touchEvents": 12.0,
+			"inputForensics": map[string]interface{}{
+				"coalescedSamples": 30.0,
+				"coalescedMax":     1.0,
+			},
+		},
+	}
+	if got := e.detectCDP(touch); hasReasonContaining(got, "never coalesced") {
+		t.Errorf("touch user should be exempt from coalesced check, got %+v", got)
+	}
+}
+
+// TestDetectVisionAI_InputForensics covers teleport clicks and agent think-time
+// cadence, including the touch/keyboard exemptions.
+func TestDetectVisionAI_InputForensics(t *testing.T) {
+	e := NewScoringEngine("test-secret")
+
+	teleport := map[string]interface{}{
+		"behavioral": map[string]interface{}{
+			"totalPoints": 40.0, "trajectoryLength": 300.0, "approachPoints": 12.0,
+			"microTremorScore": 0.4, "touchEvents": 0.0, "keyEvents": 0.0,
+			"inputForensics": map[string]interface{}{"teleportClicks": 2.0},
+		},
+	}
+	if got := e.detectVisionAI(teleport); !hasReasonContaining(got, "teleport clicks") {
+		t.Errorf("expected teleport-click detection, got %+v", got)
+	}
+
+	cadence := map[string]interface{}{
+		"behavioral": map[string]interface{}{
+			"totalPoints": 40.0, "trajectoryLength": 300.0, "approachPoints": 12.0,
+			"microTremorScore": 0.4, "touchEvents": 0.0, "keyEvents": 0.0,
+			"inputForensics": map[string]interface{}{
+				"cadenceEvents": 15.0, "cadenceSilentGaps": 4.0,
+				"cadenceGapCV": 3.0, "cadenceSilentRatio": 0.72,
+			},
+		},
+	}
+	if got := e.detectVisionAI(cadence); !hasReasonContaining(got, "act/think loop") {
+		t.Errorf("expected think-time cadence detection, got %+v", got)
+	}
+
+	// Human: one teleport-free click, continuous cadence — neither should fire.
+	human := map[string]interface{}{
+		"behavioral": map[string]interface{}{
+			"totalPoints": 40.0, "trajectoryLength": 300.0, "approachPoints": 12.0,
+			"microTremorScore": 0.4, "touchEvents": 0.0, "keyEvents": 0.0,
+			"inputForensics": map[string]interface{}{
+				"teleportClicks": 0.0, "cadenceEvents": 30.0, "cadenceSilentGaps": 1.0,
+				"cadenceGapCV": 1.2, "cadenceSilentRatio": 0.1,
+			},
+		},
+	}
+	got := e.detectVisionAI(human)
+	if hasReasonContaining(got, "teleport clicks") || hasReasonContaining(got, "act/think loop") {
+		t.Errorf("human-like input should not trip input-forensics signals, got %+v", got)
+	}
+}
+
+// TestAnalyzeFormInteraction_ProgrammaticFill covers the fill()-style insertion
+// signal: content with zero keystrokes and zero pastes.
+func TestAnalyzeFormInteraction_ProgrammaticFill(t *testing.T) {
+	e := NewScoringEngine("test-secret")
+
+	filled := map[string]interface{}{
+		"textareaKeyboard": map[string]interface{}{
+			"comment": map[string]interface{}{
+				"contentLength": 50.0, "keyCount": 0.0, "pasteCount": 0.0,
+			},
+		},
+	}
+	if got := e.AnalyzeFormInteraction(filled); !hasReasonContaining(got, "filled programmatically") {
+		t.Errorf("expected programmatic-fill detection, got %+v", got)
+	}
+
+	// Genuinely typed content must not trip it.
+	typed := map[string]interface{}{
+		"textareaKeyboard": map[string]interface{}{
+			"comment": map[string]interface{}{
+				"contentLength": 50.0, "keyCount": 48.0, "pasteCount": 0.0,
+				"avgKeyInterval": 180.0, "keyIntervalVariance": 4000.0, "keydownUpRatio": 1.0,
+			},
+		},
+	}
+	if got := e.AnalyzeFormInteraction(typed); hasReasonContaining(got, "filled programmatically") {
+		t.Errorf("typed content should not trip programmatic-fill, got %+v", got)
+	}
+}

--- a/server-node/detection.js
+++ b/server-node/detection.js
@@ -729,6 +729,18 @@ function analyzeFormInteraction(formAnalysis) {
   const textareaData = formAnalysis.textareaKeyboard;
   if (textareaData) {
     for (const [fieldId, stats] of Object.entries(textareaData)) {
+      // Programmatic fill: meaningful content appeared with zero keystrokes and
+      // zero pastes (e.g. Playwright fill() / element.value=). The length gate
+      // keeps this off browser autofill of short fields.
+      if ((stats.contentLength || 0) > 8 && (stats.keyCount || 0) === 0 && (stats.pasteCount || 0) === 0) {
+        detections.push({
+          category: 'automation',
+          score: 0.8,
+          confidence: 0.75,
+          reason: `Textarea "${fieldId}" filled programmatically (${stats.contentLength} chars, no keystrokes or paste)`
+        });
+      }
+
       // Check for paste-heavy input (spam bots often paste content)
       if (stats.pasteCount > 0 && stats.keyCount < 5) {
         detections.push({

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -337,6 +337,31 @@ function detectVisionAI(signals) {
     });
   }
 
+  // Input-event forensics: teleport clicks and agent think-time cadence.
+  const fcs = b.inputForensics;
+  if (fcs) {
+    const teleports = fcs.teleportClicks ?? 0;
+    if (teleports >= 1 && !isTouchUser) {
+      detections.push({
+        category: 'vision_ai', score: 0.7, confidence: 0.7,
+        reason: `Click injected with no pointer trajectory (${teleports} teleport clicks)`
+      });
+    }
+    // Bursts of activity separated by multi-second perfect silence — the agent
+    // act -> screenshot -> inference loop. Low confidence (slow humans idle too);
+    // requires silence to dominate. Keyboard-only users are exempt.
+    if (!isKeyboardUser &&
+        (fcs.cadenceEvents ?? 0) >= 12 &&
+        (fcs.cadenceSilentGaps ?? 0) >= 3 &&
+        (fcs.cadenceGapCV ?? 0) > 2.5 &&
+        (fcs.cadenceSilentRatio ?? 0) > 0.6) {
+      detections.push({
+        category: 'vision_ai', score: 0.6, confidence: 0.5,
+        reason: 'Interaction cadence matches agent act/think loop (bursts + dead air)'
+      });
+    }
+  }
+
   return detections;
 }
 
@@ -480,6 +505,38 @@ function detectCDP(signals) {
   const detections = [];
   const env = signals.environmental || {};
   const cdp = env.cdp || {};
+
+  // Input-event forensics: catch CDP-injected input that reports isTrusted:true
+  // and so evades the global-based checks below. Touch users are exempt.
+  const b = signals.behavioral || {};
+  const isTouchUser = (b.touchEvents ?? 0) >= 3;
+  const fcs = b.inputForensics;
+  if (fcs && !isTouchUser) {
+    // Real mice coalesce several hardware samples per frame; a stream of
+    // pointermoves that NEVER coalesced is synthetic injection.
+    if ((fcs.coalescedSamples ?? 0) >= 20 && (fcs.coalescedMax ?? 0) <= 1) {
+      detections.push({
+        category: 'cdp', score: 0.8, confidence: 0.6,
+        reason: 'Pointer moves never coalesced across many samples (synthetic/CDP input)'
+      });
+    }
+    // movementX/Y incoherent with actual position deltas across most moves.
+    if ((fcs.pointerMoveSamples ?? 0) >= 20 && (fcs.pointerMoveZeroRatio ?? 0) > 0.9) {
+      detections.push({
+        category: 'cdp', score: 0.6, confidence: 0.5,
+        reason: 'Pointer movement deltas incoherent with position (synthetic input)'
+      });
+    }
+  }
+
+  // CDP Runtime/DevTools console consumer attached. Low confidence: a developer
+  // with DevTools open also trips this, so it contributes rather than blocks.
+  if (env.cdpRuntime && env.cdpRuntime.consoleAttached) {
+    detections.push({
+      category: 'cdp', score: 0.6, confidence: 0.5,
+      reason: 'CDP/DevTools console consumer attached (automation protocol or open DevTools)'
+    });
+  }
 
   if (cdp.detected) {
     const signalList = cdp.signals || [];

--- a/server-python/detection.py
+++ b/server-python/detection.py
@@ -748,6 +748,18 @@ def analyze_form_interaction(form_analysis: Optional[Dict]) -> List[Dict]:
             avg_interval = stats.get("avgKeyInterval", 0)
             interval_variance = stats.get("keyIntervalVariance", 0)
             keydown_up_ratio = stats.get("keydownUpRatio", 1.0)
+            content_length = stats.get("contentLength", 0)
+
+            # Programmatic fill: meaningful content appeared with zero keystrokes
+            # and zero pastes (e.g. Playwright fill() / element.value=). The
+            # length gate keeps this off browser autofill of short fields.
+            if content_length > 8 and key_count == 0 and paste_count == 0:
+                detections.append({
+                    "category": "automation",
+                    "score": 0.8,
+                    "confidence": 0.75,
+                    "reason": f'Textarea "{field_id}" filled programmatically ({content_length} chars, no keystrokes or paste)'
+                })
 
             # Check for paste-heavy input (spam bots often paste content)
             if paste_count > 0 and key_count < 5:

--- a/server-python/server.py
+++ b/server-python/server.py
@@ -421,6 +421,28 @@ def detect_vision_ai(signals: Dict) -> List[Detection]:
             "No exploratory mouse movement before click"
         ))
 
+    # Input-event forensics: teleport clicks and agent think-time cadence.
+    fcs = b.get("inputForensics")
+    if fcs:
+        teleports = fcs.get("teleportClicks", 0)
+        if teleports >= 1 and not is_touch_user:
+            detections.append(Detection(
+                ThreatCategory.VISION_AI, 0.7, 0.7,
+                f"Click injected with no pointer trajectory ({int(teleports)} teleport clicks)"
+            ))
+        # Bursts of activity separated by multi-second perfect silence — the agent
+        # act -> screenshot -> inference loop. Low confidence (slow humans idle too);
+        # requires silence to dominate. Keyboard-only users are exempt.
+        if (not is_keyboard_user
+                and fcs.get("cadenceEvents", 0) >= 12
+                and fcs.get("cadenceSilentGaps", 0) >= 3
+                and fcs.get("cadenceGapCV", 0) > 2.5
+                and fcs.get("cadenceSilentRatio", 0) > 0.6):
+            detections.append(Detection(
+                ThreatCategory.VISION_AI, 0.6, 0.5,
+                "Interaction cadence matches agent act/think loop (bursts + dead air)"
+            ))
+
     return detections
 
 
@@ -549,6 +571,34 @@ def detect_cdp(signals: Dict) -> List[Detection]:
     detections = []
     env = signals.get("environmental", {})
     cdp = env.get("cdp", {})
+
+    # Input-event forensics: catch CDP-injected input that reports isTrusted=true
+    # and so evades the global-based checks below. Touch users are exempt.
+    b = signals.get("behavioral", {})
+    is_touch_user = b.get("touchEvents", 0) >= 3
+    fcs = b.get("inputForensics")
+    if fcs and not is_touch_user:
+        # Real mice coalesce several hardware samples per frame; a stream of
+        # pointermoves that NEVER coalesced is synthetic injection.
+        if fcs.get("coalescedSamples", 0) >= 20 and fcs.get("coalescedMax", 0) <= 1:
+            detections.append(Detection(
+                ThreatCategory.CDP, 0.8, 0.6,
+                "Pointer moves never coalesced across many samples (synthetic/CDP input)"
+            ))
+        # movementX/Y incoherent with actual position deltas across most moves.
+        if fcs.get("pointerMoveSamples", 0) >= 20 and fcs.get("pointerMoveZeroRatio", 0) > 0.9:
+            detections.append(Detection(
+                ThreatCategory.CDP, 0.6, 0.5,
+                "Pointer movement deltas incoherent with position (synthetic input)"
+            ))
+
+    # CDP Runtime/DevTools console consumer attached. Low confidence: a developer
+    # with DevTools open also trips this, so it contributes rather than blocks.
+    if env.get("cdpRuntime", {}).get("consoleAttached"):
+        detections.append(Detection(
+            ThreatCategory.CDP, 0.6, 0.5,
+            "CDP/DevTools console consumer attached (automation protocol or open DevTools)"
+        ))
 
     if not cdp.get("detected"):
         return detections


### PR DESCRIPTION
Implements **Phase 2** of `docs/PRD-ai-agent-detection.md` — detecting AI agents that drive a *real* browser (CDP-injected input reporting `isTrusted:true`, computer-use act/think loops) which the legacy global-based checks can't see.

## New client signals
Added to the shared `BehavioralCollector` / `EnvironmentalCollector` (so both the visible widget and invisible mode collect them):

- **`behavioral.inputForensics`**
  - `coalescedSamples` / `coalescedMax` / `coalescedEmptyRatio` / `coalescedAvg` — `pointermove.getCoalescedEvents()` batch sizes. Real mice coalesce several hardware samples per frame; CDP-injected moves produce single-entry batches.
  - `pointerMoveSamples` / `pointerMoveZeroRatio` — fraction of position-changing moves where `movementX/Y === 0` (synthetic input is incoherent).
  - `cadenceEvents` / `cadenceSilentGaps` / `cadenceGapCV` / `cadenceSilentRatio` — cross-input think-time timeline (the agent act → screenshot → inference → act loop leaves multi-second *perfect* silence between bursts).
  - `teleportClicks` — mousedown landing >150px from the last observed pointer position with no intervening movement.
- **`environmental.cdpRuntime.consoleAttached`** — Error-accessor trap fired by an attached CDP Runtime / DevTools console consumer.

All thresholds live **server-side**; the client only ships raw aggregates.

## New server detections (Go / Node / Python, in lockstep)
- **`detectCDP`**: never-coalesced pointer stream, movement incoherence, console-consumer attached.
- **`detectVisionAI`**: teleport clicks, agent act/think cadence.
- **`AnalyzeFormInteraction`**: programmatic textarea fill (content with zero keystrokes *and* zero pastes — catches Playwright `fill()` / `element.value=`).

### FP management (the PRD flagged Phase 2 as "medium FP")
- Every mouse-pointer signal is exempt for touch users; cadence is exempt for keyboard-only users.
- Conservative thresholds (e.g. coalesced requires ≥20 samples and `max ≤ 1`; cadence requires silence to dominate the interaction).
- The genuinely FP-prone signals (CDP console attach = open DevTools; cadence = slow humans) ship at **low confidence** so they contribute rather than block. The strong, low-FP ones (coalesced absence, teleport, programmatic fill) carry higher confidence.
- Existing human fixtures don't include `inputForensics` → `getMap` returns nil → none of the new checks fire. No regression on current tests.

## Deviation from the PRD draft
Dropped the **constant-pressure** sub-signal from §5.2: a real mouse hovering (moving without a button) reports `pressure === 0` on *every* move, so a constant-pressure check false-positives on all mouse users. Kept **movement coherence** only. Documented inline in the PRD.

## Tests
- Go unit tests: `TestDetectCDP_InputForensics`, `TestDetectVisionAI_InputForensics`, `TestAnalyzeFormInteraction_ProgrammaticFill` — positive, negative (human-like), and touch-exempt cases. Full suite + `go vet` green.
- Node & Python detectors verified functionally (synthetic trips, human-like stays clean, touch exempt) via isolated harnesses.
- Client passes `node --check`.

## PRD status
Marks Phases 1–2 shipped. Remaining: hosted-agent env composites (§7), a11y honeypots (§8), cross-session correlation (§9), Web Bot Auth signature verification (§4.3 v2).