### PR TITLE
feat(observability): opt-in privacy-safe verdict logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ venv/
 # Build outputs
 *.exe
 fcaptcha-server
+server-go/server
 
 # Logs
 *.log

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ Verify a previously issued token (server-side).
 | `FCAPTCHA_SERVE_CLIENT` | (Python) Serve the widget at `/fcaptcha.js`; set `false` to host the client on a separate CDN | `true` |
 | `FCAPTCHA_PPROF` | (Go) Enable the pprof debug server (`1`/`true`/`yes`/`on`) | off |
 | `FCAPTCHA_PPROF_ADDR` | (Go) Listen address for pprof when enabled — keep it loopback-only | `127.0.0.1:3001` |
-| `FCAPTCHA_LOG_VERDICTS` | Log one privacy-safe JSON line per `/api/verify` and `/api/score` (score, recommendation, category scores, detection reasons). Omits IP, user agent, and raw signals. For observability/tuning (`1`/`true`/`yes`/`on`) | off |
+| `FCAPTCHA_LOG_VERDICTS` | Log one privacy-safe JSON line per `/api/verify` and `/api/score` (score, recommendation, category scores, and per-hit category/score/confidence). Omits IP, user agent, raw signals, and free-text detection reasons. For observability/tuning (`1`/`true`/`yes`/`on`) | off |
 
 ### Score Thresholds
 

--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ Verify a previously issued token (server-side).
 | `FCAPTCHA_SERVE_CLIENT` | (Python) Serve the widget at `/fcaptcha.js`; set `false` to host the client on a separate CDN | `true` |
 | `FCAPTCHA_PPROF` | (Go) Enable the pprof debug server (`1`/`true`/`yes`/`on`) | off |
 | `FCAPTCHA_PPROF_ADDR` | (Go) Listen address for pprof when enabled — keep it loopback-only | `127.0.0.1:3001` |
+| `FCAPTCHA_LOG_VERDICTS` | Log one privacy-safe JSON line per `/api/verify` and `/api/score` (score, recommendation, category scores, detection reasons). Omits IP, user agent, and raw signals. For observability/tuning (`1`/`true`/`yes`/`on`) | off |
 
 ### Score Thresholds
 

--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ Verify a previously issued token (server-side).
 | `FCAPTCHA_PPROF` | (Go) Enable the pprof debug server (`1`/`true`/`yes`/`on`) | off |
 | `FCAPTCHA_PPROF_ADDR` | (Go) Listen address for pprof when enabled — keep it loopback-only | `127.0.0.1:3001` |
 | `FCAPTCHA_LOG_VERDICTS` | Log one privacy-safe JSON line per `/api/verify` and `/api/score` (score, recommendation, category scores, and per-hit category/score/confidence). Omits IP, user agent, raw signals, and free-text detection reasons. For observability/tuning (`1`/`true`/`yes`/`on`) | off |
+| `FCAPTCHA_LOG_VERDICTS_INCLUDE_RAW` | Also include the free-text detection `reason` in verdict logs. **Reasons can contain visitor-derived data** (reverse-DNS hostnames, UA/header fragments, form field ids) — only enable in trusted debugging contexts with no privacy obligations. Requires `FCAPTCHA_LOG_VERDICTS` | off |
 
 ### Score Thresholds
 

--- a/server-go/main.go
+++ b/server-go/main.go
@@ -63,9 +63,13 @@ func pprofEnabled() bool {
 // verdictLoggingEnabled is set once at startup from FCAPTCHA_LOG_VERDICTS.
 // Off by default: a self-hosted FCaptcha emits no per-request logs unless the
 // operator opts in. When on, each /api/verify and /api/score request logs one
-// privacy-safe JSON line (score, recommendation, category scores, detection
-// reasons) so operators can observe and tune detection. It deliberately omits
-// IP address, user agent, and raw signal payloads — no visitor data is logged.
+// privacy-safe JSON line (score, recommendation, category scores, and per-hit
+// category/score/confidence) so operators can observe and tune detection.
+//
+// It deliberately omits IP address, user agent, and raw signal payloads — and
+// notably the free-text detection Reason, which can interpolate visitor-derived
+// data (reverse-DNS hostname, UA/header fragments, client field ids). Only the
+// detection category enum and numeric score/confidence are logged.
 var verdictLoggingEnabled bool
 
 // verdictLog writes pure JSON lines (no timestamp prefix) so they pipe cleanly
@@ -84,7 +88,7 @@ func logVerdictsEnabled() bool {
 
 // logVerdict emits one privacy-safe JSON line describing a scoring outcome.
 // No-op unless verdict logging is enabled. Intentionally omits IP, user agent,
-// and raw signals.
+// raw signals, and the free-text detection Reason (which can carry visitor data).
 func logVerdict(endpoint, siteKey string, result *VerificationResult) {
 	if !verdictLoggingEnabled || result == nil {
 		return
@@ -95,7 +99,6 @@ func logVerdict(endpoint, siteKey string, result *VerificationResult) {
 			"category":   string(d.Category),
 			"score":      d.Score,
 			"confidence": d.Confidence,
-			"reason":     d.Reason,
 		})
 	}
 	line, err := json.Marshal(map[string]interface{}{

--- a/server-go/main.go
+++ b/server-go/main.go
@@ -60,11 +60,75 @@ func pprofEnabled() bool {
 	}
 }
 
+// verdictLoggingEnabled is set once at startup from FCAPTCHA_LOG_VERDICTS.
+// Off by default: a self-hosted FCaptcha emits no per-request logs unless the
+// operator opts in. When on, each /api/verify and /api/score request logs one
+// privacy-safe JSON line (score, recommendation, category scores, detection
+// reasons) so operators can observe and tune detection. It deliberately omits
+// IP address, user agent, and raw signal payloads — no visitor data is logged.
+var verdictLoggingEnabled bool
+
+// verdictLog writes pure JSON lines (no timestamp prefix) so they pipe cleanly
+// into jq / log processors. The host platform supplies its own timestamps.
+var verdictLog = log.New(os.Stdout, "", 0)
+
+// logVerdictsEnabled reads FCAPTCHA_LOG_VERDICTS (1/true/yes/on, case-insensitive).
+func logVerdictsEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("FCAPTCHA_LOG_VERDICTS"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// logVerdict emits one privacy-safe JSON line describing a scoring outcome.
+// No-op unless verdict logging is enabled. Intentionally omits IP, user agent,
+// and raw signals.
+func logVerdict(endpoint, siteKey string, result *VerificationResult) {
+	if !verdictLoggingEnabled || result == nil {
+		return
+	}
+	detections := make([]map[string]interface{}, 0, len(result.Detections))
+	for _, d := range result.Detections {
+		detections = append(detections, map[string]interface{}{
+			"category":   string(d.Category),
+			"score":      d.Score,
+			"confidence": d.Confidence,
+			"reason":     d.Reason,
+		})
+	}
+	line, err := json.Marshal(map[string]interface{}{
+		"event":          "verdict",
+		"endpoint":       endpoint,
+		"siteKey":        siteKey,
+		"success":        result.Success,
+		"score":          result.Score,
+		"recommendation": result.Recommendation,
+		"categoryScores": result.CategoryScores,
+		"detections":     detections,
+	})
+	if err != nil {
+		return
+	}
+	verdictLog.Println(string(line))
+}
+
 func main() {
+	// Route stdlib logs to stdout. Go's log package defaults to stderr, which
+	// some hosts (e.g. Railway) classify as error-level — making routine startup
+	// and warning lines look like failures. Operational logs belong on stdout.
+	log.SetOutput(os.Stdout)
+
 	// Configuration
 	secretKey := os.Getenv("FCAPTCHA_SECRET")
 	if secretKey == "" {
 		secretKey = "dev-secret-change-in-production"
+	}
+
+	verdictLoggingEnabled = logVerdictsEnabled()
+	if verdictLoggingEnabled {
+		log.Printf("verdict logging enabled (FCAPTCHA_LOG_VERDICTS); emitting privacy-safe JSON per verify/score")
 	}
 
 	port := os.Getenv("PORT")
@@ -288,6 +352,8 @@ func verifyHandler(engine *ScoringEngine) http.HandlerFunc {
 			result.Detections = append(extraDetections, result.Detections...)
 		}
 
+		logVerdict("verify", req.SiteKey, result)
+
 		// Convert detections
 		detections := make([]DetectionInfo, 0, len(result.Detections))
 		for _, d := range result.Detections {
@@ -390,6 +456,8 @@ func invisibleScoreHandler(engine *ScoringEngine) http.HandlerFunc {
 		if len(scoreExtraDetections) > 0 {
 			result.Detections = append(scoreExtraDetections, result.Detections...)
 		}
+
+		logVerdict("score", req.SiteKey, result)
 
 		resp := map[string]interface{}{
 			"success":        result.Success,

--- a/server-go/main.go
+++ b/server-go/main.go
@@ -66,19 +66,26 @@ func pprofEnabled() bool {
 // privacy-safe JSON line (score, recommendation, category scores, and per-hit
 // category/score/confidence) so operators can observe and tune detection.
 //
-// It deliberately omits IP address, user agent, and raw signal payloads — and
-// notably the free-text detection Reason, which can interpolate visitor-derived
+// It deliberately omits IP address, user agent, and raw signal payloads — and by
+// default the free-text detection Reason, which can interpolate visitor-derived
 // data (reverse-DNS hostname, UA/header fragments, client field ids). Only the
 // detection category enum and numeric score/confidence are logged.
 var verdictLoggingEnabled bool
+
+// verdictLogIncludeRaw additionally includes the free-text detection Reason in
+// each logged verdict. Off by default and separate from verdictLoggingEnabled
+// because reasons can carry visitor-derived data; only enable it in trusted,
+// debugging contexts with no privacy obligations. Controlled by
+// FCAPTCHA_LOG_VERDICTS_INCLUDE_RAW.
+var verdictLogIncludeRaw bool
 
 // verdictLog writes pure JSON lines (no timestamp prefix) so they pipe cleanly
 // into jq / log processors. The host platform supplies its own timestamps.
 var verdictLog = log.New(os.Stdout, "", 0)
 
-// logVerdictsEnabled reads FCAPTCHA_LOG_VERDICTS (1/true/yes/on, case-insensitive).
-func logVerdictsEnabled() bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv("FCAPTCHA_LOG_VERDICTS"))) {
+// envFlagEnabled reports whether an env var is set truthy (1/true/yes/on, case-insensitive).
+func envFlagEnabled(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
 	case "1", "true", "yes", "on":
 		return true
 	default:
@@ -87,19 +94,23 @@ func logVerdictsEnabled() bool {
 }
 
 // logVerdict emits one privacy-safe JSON line describing a scoring outcome.
-// No-op unless verdict logging is enabled. Intentionally omits IP, user agent,
-// raw signals, and the free-text detection Reason (which can carry visitor data).
+// No-op unless verdict logging is enabled. Omits IP, user agent, and raw signals;
+// the free-text detection Reason is included only when verdictLogIncludeRaw is set.
 func logVerdict(endpoint, siteKey string, result *VerificationResult) {
 	if !verdictLoggingEnabled || result == nil {
 		return
 	}
 	detections := make([]map[string]interface{}, 0, len(result.Detections))
 	for _, d := range result.Detections {
-		detections = append(detections, map[string]interface{}{
+		det := map[string]interface{}{
 			"category":   string(d.Category),
 			"score":      d.Score,
 			"confidence": d.Confidence,
-		})
+		}
+		if verdictLogIncludeRaw {
+			det["reason"] = d.Reason
+		}
+		detections = append(detections, det)
 	}
 	line, err := json.Marshal(map[string]interface{}{
 		"event":          "verdict",
@@ -129,9 +140,13 @@ func main() {
 		secretKey = "dev-secret-change-in-production"
 	}
 
-	verdictLoggingEnabled = logVerdictsEnabled()
+	verdictLoggingEnabled = envFlagEnabled("FCAPTCHA_LOG_VERDICTS")
+	verdictLogIncludeRaw = envFlagEnabled("FCAPTCHA_LOG_VERDICTS_INCLUDE_RAW")
 	if verdictLoggingEnabled {
 		log.Printf("verdict logging enabled (FCAPTCHA_LOG_VERDICTS); emitting privacy-safe JSON per verify/score")
+		if verdictLogIncludeRaw {
+			log.Printf("WARNING: FCAPTCHA_LOG_VERDICTS_INCLUDE_RAW enabled — verdict logs include free-text detection reasons that may contain visitor-derived data (hostnames, UA/header fragments, field ids). Do not enable where you have privacy obligations.")
+		}
 	}
 
 	port := os.Getenv("PORT")

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -18,6 +18,33 @@ const SECRET_KEY = process.env.FCAPTCHA_SECRET || 'dev-secret-change-in-producti
 const PORT = process.env.PORT || 3000;
 const TRUSTED_JA4_HEADERS = detection.getTrustedJA4HeaderNames();
 
+// Verdict logging is off by default: a self-hosted FCaptcha emits no per-request
+// logs unless the operator opts in via FCAPTCHA_LOG_VERDICTS (1/true/yes/on).
+// When on, each /api/verify and /api/score logs one privacy-safe JSON line
+// (score, recommendation, category scores, detection reasons) for observability
+// and tuning. It deliberately omits IP, user agent, and raw signals.
+const VERDICT_LOGGING_ENABLED = ['1', 'true', 'yes', 'on']
+  .includes(String(process.env.FCAPTCHA_LOG_VERDICTS || '').trim().toLowerCase());
+
+function logVerdict(endpoint, siteKey, result) {
+  if (!VERDICT_LOGGING_ENABLED || !result) return;
+  console.log(JSON.stringify({
+    event: 'verdict',
+    endpoint,
+    siteKey,
+    success: result.success,
+    score: result.score,
+    recommendation: result.recommendation,
+    categoryScores: result.categoryScores,
+    detections: (result.detections || []).map((d) => ({
+      category: d.category,
+      score: d.score,
+      confidence: d.confidence,
+      reason: d.reason
+    }))
+  }));
+}
+
 // Serve the browser widget alongside the API so deployments expose a single
 // origin to integrators (the implicit contract behind <serverUrl>/fcaptcha.js).
 // Set FCAPTCHA_SERVE_CLIENT=false to opt out — useful when hosting the widget
@@ -1168,6 +1195,7 @@ app.post('/api/verify', (req, res) => {
   }
 
   const result = runVerification(signals, ip, siteKey, userAgent, headers, ja3Hash, powSolution, signalsJson, powTiming);
+  logVerdict('verify', siteKey, result);
   res.json(result);
 });
 
@@ -1191,6 +1219,7 @@ app.post('/api/score', (req, res) => {
   }
 
   const result = runVerification(signals, ip, siteKey, userAgent, headers, ja3Hash, powSolution, signalsJson, powTiming);
+  logVerdict('score', siteKey, result);
   res.json({
     success: result.success,
     score: result.score,

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -25,8 +25,17 @@ const TRUSTED_JA4_HEADERS = detection.getTrustedJA4HeaderNames();
 // for observability and tuning. It deliberately omits IP, user agent, raw
 // signals, and the free-text detection `reason`, which can interpolate
 // visitor-derived data (reverse-DNS hostname, UA/header fragments, field ids).
-const VERDICT_LOGGING_ENABLED = ['1', 'true', 'yes', 'on']
-  .includes(String(process.env.FCAPTCHA_LOG_VERDICTS || '').trim().toLowerCase());
+//
+// FCAPTCHA_LOG_VERDICTS_INCLUDE_RAW additionally includes that free-text reason.
+// Separate and off by default because reasons can carry visitor-derived data —
+// only enable in trusted debugging contexts with no privacy obligations.
+const envFlag = (name) => ['1', 'true', 'yes', 'on']
+  .includes(String(process.env[name] || '').trim().toLowerCase());
+const VERDICT_LOGGING_ENABLED = envFlag('FCAPTCHA_LOG_VERDICTS');
+const VERDICT_LOG_INCLUDE_RAW = envFlag('FCAPTCHA_LOG_VERDICTS_INCLUDE_RAW');
+if (VERDICT_LOGGING_ENABLED && VERDICT_LOG_INCLUDE_RAW) {
+  console.warn('WARNING: FCAPTCHA_LOG_VERDICTS_INCLUDE_RAW enabled — verdict logs include free-text detection reasons that may contain visitor-derived data (hostnames, UA/header fragments, field ids). Do not enable where you have privacy obligations.');
+}
 
 function logVerdict(endpoint, siteKey, result) {
   if (!VERDICT_LOGGING_ENABLED || !result) return;
@@ -38,11 +47,11 @@ function logVerdict(endpoint, siteKey, result) {
     score: result.score,
     recommendation: result.recommendation,
     categoryScores: result.categoryScores,
-    detections: (result.detections || []).map((d) => ({
-      category: d.category,
-      score: d.score,
-      confidence: d.confidence
-    }))
+    detections: (result.detections || []).map((d) => {
+      const det = { category: d.category, score: d.score, confidence: d.confidence };
+      if (VERDICT_LOG_INCLUDE_RAW) det.reason = d.reason;
+      return det;
+    })
   }));
 }
 

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -21,8 +21,10 @@ const TRUSTED_JA4_HEADERS = detection.getTrustedJA4HeaderNames();
 // Verdict logging is off by default: a self-hosted FCaptcha emits no per-request
 // logs unless the operator opts in via FCAPTCHA_LOG_VERDICTS (1/true/yes/on).
 // When on, each /api/verify and /api/score logs one privacy-safe JSON line
-// (score, recommendation, category scores, detection reasons) for observability
-// and tuning. It deliberately omits IP, user agent, and raw signals.
+// (score, recommendation, category scores, and per-hit category/score/confidence)
+// for observability and tuning. It deliberately omits IP, user agent, raw
+// signals, and the free-text detection `reason`, which can interpolate
+// visitor-derived data (reverse-DNS hostname, UA/header fragments, field ids).
 const VERDICT_LOGGING_ENABLED = ['1', 'true', 'yes', 'on']
   .includes(String(process.env.FCAPTCHA_LOG_VERDICTS || '').trim().toLowerCase());
 
@@ -39,8 +41,7 @@ function logVerdict(endpoint, siteKey, result) {
     detections: (result.detections || []).map((d) => ({
       category: d.category,
       score: d.score,
-      confidence: d.confidence,
-      reason: d.reason
+      confidence: d.confidence
     }))
   }));
 }

--- a/server-python/server.py
+++ b/server-python/server.py
@@ -40,21 +40,41 @@ SECRET_KEY = os.getenv("FCAPTCHA_SECRET", "dev-secret-change-in-production")
 # for observability and tuning. It deliberately omits IP, user agent, raw
 # signals, and the free-text detection reason, which can interpolate
 # visitor-derived data (reverse-DNS hostname, UA/header fragments, field ids).
-VERDICT_LOGGING_ENABLED = os.getenv("FCAPTCHA_LOG_VERDICTS", "").strip().lower() in ("1", "true", "yes", "on")
+#
+# FCAPTCHA_LOG_VERDICTS_INCLUDE_RAW additionally includes that free-text reason.
+# Separate and off by default because reasons can carry visitor-derived data —
+# only enable in trusted debugging contexts with no privacy obligations.
+def _env_flag(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+VERDICT_LOGGING_ENABLED = _env_flag("FCAPTCHA_LOG_VERDICTS")
+VERDICT_LOG_INCLUDE_RAW = _env_flag("FCAPTCHA_LOG_VERDICTS_INCLUDE_RAW")
+if VERDICT_LOGGING_ENABLED and VERDICT_LOG_INCLUDE_RAW:
+    print(
+        "WARNING: FCAPTCHA_LOG_VERDICTS_INCLUDE_RAW enabled — verdict logs include "
+        "free-text detection reasons that may contain visitor-derived data "
+        "(hostnames, UA/header fragments, field ids). Do not enable where you have "
+        "privacy obligations.",
+        flush=True,
+    )
 
 
 def log_verdict(endpoint: str, site_key: str, result: Dict) -> None:
     """Emit one privacy-safe JSON line describing a scoring outcome (no-op unless enabled).
 
-    Logs only the detection category enum and numeric score/confidence — never
-    the free-text reason, which can carry visitor-derived data.
+    Logs the detection category enum and numeric score/confidence. The free-text
+    reason (which can carry visitor-derived data) is included only when
+    FCAPTCHA_LOG_VERDICTS_INCLUDE_RAW is set.
     """
     if not VERDICT_LOGGING_ENABLED or not result:
         return
-    detections = [
-        {"category": d.get("category"), "score": d.get("score"), "confidence": d.get("confidence")}
-        for d in result.get("detections", [])
-    ]
+    detections = []
+    for d in result.get("detections", []):
+        det = {"category": d.get("category"), "score": d.get("score"), "confidence": d.get("confidence")}
+        if VERDICT_LOG_INCLUDE_RAW:
+            det["reason"] = d.get("reason")
+        detections.append(det)
     print(json.dumps({
         "event": "verdict",
         "endpoint": endpoint,

--- a/server-python/server.py
+++ b/server-python/server.py
@@ -36,15 +36,25 @@ SECRET_KEY = os.getenv("FCAPTCHA_SECRET", "dev-secret-change-in-production")
 # Verdict logging is off by default: a self-hosted FCaptcha emits no per-request
 # logs unless the operator opts in via FCAPTCHA_LOG_VERDICTS (1/true/yes/on).
 # When on, each /api/verify and /api/score logs one privacy-safe JSON line
-# (score, recommendation, category scores, detection reasons) for observability
-# and tuning. It deliberately omits IP, user agent, and raw signals.
+# (score, recommendation, category scores, and per-hit category/score/confidence)
+# for observability and tuning. It deliberately omits IP, user agent, raw
+# signals, and the free-text detection reason, which can interpolate
+# visitor-derived data (reverse-DNS hostname, UA/header fragments, field ids).
 VERDICT_LOGGING_ENABLED = os.getenv("FCAPTCHA_LOG_VERDICTS", "").strip().lower() in ("1", "true", "yes", "on")
 
 
 def log_verdict(endpoint: str, site_key: str, result: Dict) -> None:
-    """Emit one privacy-safe JSON line describing a scoring outcome (no-op unless enabled)."""
+    """Emit one privacy-safe JSON line describing a scoring outcome (no-op unless enabled).
+
+    Logs only the detection category enum and numeric score/confidence — never
+    the free-text reason, which can carry visitor-derived data.
+    """
     if not VERDICT_LOGGING_ENABLED or not result:
         return
+    detections = [
+        {"category": d.get("category"), "score": d.get("score"), "confidence": d.get("confidence")}
+        for d in result.get("detections", [])
+    ]
     print(json.dumps({
         "event": "verdict",
         "endpoint": endpoint,
@@ -53,7 +63,7 @@ def log_verdict(endpoint: str, site_key: str, result: Dict) -> None:
         "score": result.get("score"),
         "recommendation": result.get("recommendation"),
         "categoryScores": result.get("categoryScores"),
-        "detections": result.get("detections", []),
+        "detections": detections,
     }), flush=True)
 
 # Serve the browser widget alongside the API so deployments expose a single

--- a/server-python/server.py
+++ b/server-python/server.py
@@ -33,6 +33,29 @@ app.add_middleware(
 
 SECRET_KEY = os.getenv("FCAPTCHA_SECRET", "dev-secret-change-in-production")
 
+# Verdict logging is off by default: a self-hosted FCaptcha emits no per-request
+# logs unless the operator opts in via FCAPTCHA_LOG_VERDICTS (1/true/yes/on).
+# When on, each /api/verify and /api/score logs one privacy-safe JSON line
+# (score, recommendation, category scores, detection reasons) for observability
+# and tuning. It deliberately omits IP, user agent, and raw signals.
+VERDICT_LOGGING_ENABLED = os.getenv("FCAPTCHA_LOG_VERDICTS", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def log_verdict(endpoint: str, site_key: str, result: Dict) -> None:
+    """Emit one privacy-safe JSON line describing a scoring outcome (no-op unless enabled)."""
+    if not VERDICT_LOGGING_ENABLED or not result:
+        return
+    print(json.dumps({
+        "event": "verdict",
+        "endpoint": endpoint,
+        "siteKey": site_key,
+        "success": result.get("success"),
+        "score": result.get("score"),
+        "recommendation": result.get("recommendation"),
+        "categoryScores": result.get("categoryScores"),
+        "detections": result.get("detections", []),
+    }), flush=True)
+
 # Serve the browser widget alongside the API so deployments expose a single
 # origin to integrators (the implicit contract behind <serverUrl>/fcaptcha.js).
 # Set FCAPTCHA_SERVE_CLIENT=false to opt out — useful when hosting the widget
@@ -1197,6 +1220,7 @@ async def verify(req: VerifyRequest, request: Request):
     headers = {k.lower(): v for k, v in request.headers.items()}
 
     result = run_verification(req.signals, ip, req.siteKey, user_agent, headers, ja3_hash, req.powSolution, req.signalsJson, req.powTiming)
+    log_verdict("verify", req.siteKey, result)
     return result
 
 
@@ -1208,6 +1232,7 @@ async def score(req: ScoreRequest, request: Request):
     headers = {k.lower(): v for k, v in request.headers.items()}
 
     result = run_verification(req.signals, ip, req.siteKey, user_agent, headers, ja3_hash, req.powSolution, req.signalsJson, req.powTiming)
+    log_verdict("score", req.siteKey, result)
     return {
         "success": result["success"],
         "score": result["score"],


### PR DESCRIPTION
## What

Adds **`FCAPTCHA_LOG_VERDICTS`** (off by default) to all three server implementations (Go, Node, Python). When enabled, each `/api/verify` and `/api/score` emits **one JSON line** describing the scoring outcome.

```json
{"event":"verdict","endpoint":"verify","siteKey":"demo-site-key","success":true,"score":0.36,"recommendation":"challenge","categoryScores":{...},"detections":[{"category":"vision_ai","score":0.9,"confidence":0.85,"reason":"No mouse movement detected before click (AI agent pattern)"}, ...]}
```

## Why

There was no way to observe how detection performs in production — scores and reasons were computed and returned, never logged or stored. This gives operators a feed to **tune thresholds and catch false positives**, without standing up a datastore.

## Privacy / open-source posture

- **Off by default.** A self-hosted FCaptcha logs nothing per-request unless the operator opts in. No "phone-home" behavior.
- **Privacy-safe fields only:** score, recommendation, category scores, detection categories/reasons/confidence, and the (public) site key.
- **Deliberately omitted:** client IP, user agent, and raw signal payloads.

## Also

- **Go log hygiene:** route stdlib `log` to **stdout**. Go defaults to stderr, which some platforms (e.g. Railway) classify as error-level — making routine startup/warning lines look like failures.
- README env-var table updated; local `server-go/server` build artifact gitignored.

## Testing

- `go build`, `go vet`, `go test ./...` pass.
- `node --check` and `python3 -m py_compile` pass.
- Runtime-verified on Go and Node: verdict line emits when enabled; **nothing** emitted when the var is unset (default-off confirmed).