### PR TITLE
chore(go): use real module path so the server is go-installable

### DIFF
--- a/server-go/go.mod
+++ b/server-go/go.mod
@@ -1,4 +1,4 @@
-module github.com/fcaptcha/server
+module github.com/WebDecoy/FCaptcha/server-go
 
 go 1.21
 


### PR DESCRIPTION
Renames the Go module from the placeholder `github.com/fcaptcha/server` to `github.com/WebDecoy/FCaptcha/server-go` (matching the repo path).

## Why
The old path was a bogus placeholder that doesn't resolve. With the correct path:
- `go install github.com/WebDecoy/FCaptcha/server-go@latest` builds the server binary
- the module resolves on pkg.go.dev

## Scope
One line in `server-go/go.mod`. All files are `package main` and nothing imports the old path, so no code changes are needed. The demo backend vendors a separate module and is unaffected.

`go build`, `go vet`, and `go test ./...` all pass.

Note: this makes the binary installable; it does **not** expose an importable library API (the engine is still `package main`). Extracting an embeddable `package fcaptcha` would be a separate change.