### PR TITLE
feat(detection): stealth-patch artifact detection for cloud AI agents (#15)

### DIFF
--- a/client/fcaptcha.js
+++ b/client/fcaptcha.js
@@ -1023,6 +1023,7 @@
         cdp: this._detectCDP(),
         cdpRuntime: this._detectCDPRuntime(),
         playwright: this._detectPlaywright(),
+        stealthArtifacts: this._detectStealthArtifacts(),
 
         // Browser fingerprints
         canvasHash: this._getCanvasHash(),
@@ -1051,12 +1052,13 @@
 
     // Async detections collected separately
     async collectAsync() {
-      const [speechInfo, webrtcInfo, workerConsistency] = await Promise.all([
+      const [speechInfo, webrtcInfo, workerConsistency, permissionProbe] = await Promise.all([
         this._getSpeechInfo(),
         this._getWebRTCInfo(),
-        this._checkWorkerConsistency()
+        this._checkWorkerConsistency(),
+        this._checkPermissionContradiction()
       ]);
-      return { speechInfo, webrtcInfo, workerConsistency };
+      return { speechInfo, webrtcInfo, workerConsistency, permissionProbe };
     }
 
     _detectWebdriver() {
@@ -1155,6 +1157,78 @@
         return { detected: signals.length > 0, signals };
       } catch (e) {
         return { detected: false, signals: [] };
+      }
+    }
+
+    // Detect stealth-automation patch artifacts. A genuine browser keeps its
+    // built-in functions native and internally consistent. Anti-detection
+    // tooling (puppeteer-extra-stealth, patchright, etc.) overrides natives to
+    // spoof fingerprints and then hides the overrides — leaving traces a real
+    // user never produces. Returns a list of signal strings; the server scores
+    // only the false-positive-safe ones (see server detectStealthArtifacts).
+    _detectStealthArtifacts() {
+      const signals = [];
+      try {
+        // Pristine reference to the native toString. Used to stringify other
+        // functions so a patched Function.prototype.toString can't mask them.
+        const fnToString = Function.prototype.toString;
+        const isNative = (fn) => {
+          if (typeof fn !== 'function') return true; // not a function: ignore
+          try {
+            return /\{\s*\[native code\]\s*\}/.test(fnToString.call(fn));
+          } catch (e) {
+            // A throwing toString is itself anomalous, but be conservative.
+            return true;
+          }
+        };
+
+        // 1. FP-SAFE: Function.prototype.toString itself must be native.
+        //    Stealth tooling proxies it to make its other overrides look native
+        //    — essentially the signature move of anti-detection frameworks.
+        //    Real browsers (and privacy extensions) leave it untouched.
+        if (!isNative(fnToString)) signals.push('tostring_proxied');
+
+        // 2. Observability only (NOT scored server-side): native functions that
+        //    stealth tooling commonly overrides. Legitimate privacy/anti-
+        //    fingerprint extensions also patch some of these (canvas/webgl), so
+        //    they are collected for analysis but never affect the verdict.
+        const watched = {
+          'permissions_query': navigator.permissions && navigator.permissions.query,
+          'webgl_getparameter': typeof WebGLRenderingContext !== 'undefined' && WebGLRenderingContext.prototype.getParameter,
+          'canvas_todataurl': typeof HTMLCanvasElement !== 'undefined' && HTMLCanvasElement.prototype.toDataURL,
+        };
+        for (const name in watched) {
+          const fn = watched[name];
+          if (fn && !isNative(fn)) signals.push('patched_' + name);
+        }
+      } catch (e) {
+        // Never let collection throw.
+      }
+      return { signals };
+    }
+
+    // FP-SAFE permission-state contradiction. In a real browser, when
+    // Notification.permission is "denied" the Permissions API must also report
+    // "denied". Headless/stealth Chromium classically reports "denied" while the
+    // Permissions API still says "prompt" (or stealth tooling patches query to
+    // paper over it but misses an edge) — a state a genuine browser can't reach.
+    async _checkPermissionContradiction() {
+      try {
+        if (typeof Notification === 'undefined' || !navigator.permissions || !navigator.permissions.query) {
+          return { supported: false };
+        }
+        const notif = Notification.permission;
+        let queryState = null;
+        try {
+          const status = await navigator.permissions.query({ name: 'notifications' });
+          queryState = status && status.state;
+        } catch (e) {
+          return { supported: false };
+        }
+        const contradiction = notif === 'denied' && queryState === 'prompt';
+        return { supported: true, notificationPermission: notif, queryState, contradiction };
+      } catch (e) {
+        return { supported: false };
       }
     }
 

--- a/server-go/scoring.go
+++ b/server-go/scoring.go
@@ -352,6 +352,7 @@ func (e *ScoringEngine) VerifyWithHeaders(signals map[string]interface{}, ip, si
 	// Behavioral detectors
 	detections = append(detections, e.detectVisionAI(signals)...)
 	detections = append(detections, e.detectHeadless(signals, userAgent)...)
+	detections = append(detections, e.detectStealthArtifacts(signals)...)
 	detections = append(detections, e.detectAutomation(signals)...)
 	detections = append(detections, e.detectCDP(signals)...)
 	detections = append(detections, e.detectBehavioral(signals)...)
@@ -939,6 +940,54 @@ func (e *ScoringEngine) detectHeadless(signals map[string]interface{}, userAgent
 				}
 			}
 		}
+	}
+
+	return results
+}
+
+// detectStealthArtifacts flags anti-detection patch traces collected by the
+// client. These are FALSE-POSITIVE-SAFE: a genuine browser never produces them,
+// because they are internal contradictions / native-function tampering rather
+// than environment-shape heuristics (which would misfire on real Linux/VPN
+// users). Targets stealth-automation agents (e.g. Manus AI) running real but
+// patched Chromium. Only the two FP-safe signals are scored; the client also
+// collects privacy-extension-ambiguous artifacts (patched_*) for observability
+// that are intentionally NOT scored here. Keep in sync with server-node/python.
+func (e *ScoringEngine) detectStealthArtifacts(signals map[string]interface{}) []DetectionResult {
+	results := make([]DetectionResult, 0)
+
+	env := getMap(signals, "environmental")
+	if env == nil {
+		return results
+	}
+
+	// Function.prototype.toString proxied — the signature move of stealth
+	// frameworks (used to make their other native overrides look untouched).
+	if artifacts := getMap(env, "stealthArtifacts"); artifacts != nil {
+		if list, ok := artifacts["signals"].([]interface{}); ok {
+			for _, s := range list {
+				if str, ok := s.(string); ok && str == "tostring_proxied" {
+					results = append(results, DetectionResult{
+						Category:   CategoryHeadless,
+						Score:      0.9,
+						Confidence: 0.85,
+						Reason:     "Function.prototype.toString is proxied (stealth automation patch)",
+					})
+					break
+				}
+			}
+		}
+	}
+
+	// Notification.permission == "denied" while the Permissions API reports
+	// "prompt": a state a real browser cannot reach (classic headless tell).
+	if probe := getMap(env, "permissionProbe"); getBool(probe, "contradiction") {
+		results = append(results, DetectionResult{
+			Category:   CategoryHeadless,
+			Score:      0.85,
+			Confidence: 0.85,
+			Reason:     "Notification permission contradicts Permissions API (headless/stealth tell)",
+		})
 	}
 
 	return results

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -495,6 +495,39 @@ function detectHeadless(signals, userAgent) {
   return detections;
 }
 
+// Flags anti-detection patch traces collected by the client. FALSE-POSITIVE-
+// SAFE: a genuine browser never produces these (internal contradictions /
+// native-function tampering, not environment-shape heuristics that would
+// misfire on real Linux/VPN users). Targets stealth agents (e.g. Manus AI)
+// driving real-but-patched Chromium. Only the two FP-safe signals are scored;
+// the client also collects privacy-extension-ambiguous artifacts (patched_*)
+// for observability that are intentionally NOT scored. Keep in sync with Go/Py.
+function detectStealthArtifacts(signals) {
+  const detections = [];
+  const env = signals.environmental || {};
+
+  // Function.prototype.toString proxied — the signature move of stealth
+  // frameworks (used to make their other native overrides look untouched).
+  const artifactSignals = (env.stealthArtifacts && env.stealthArtifacts.signals) || [];
+  if (artifactSignals.includes('tostring_proxied')) {
+    detections.push({
+      category: 'headless', score: 0.9, confidence: 0.85,
+      reason: 'Function.prototype.toString is proxied (stealth automation patch)'
+    });
+  }
+
+  // Notification.permission === 'denied' while the Permissions API reports
+  // 'prompt': a state a real browser cannot reach (classic headless tell).
+  if (env.permissionProbe && env.permissionProbe.contradiction === true) {
+    detections.push({
+      category: 'headless', score: 0.85, confidence: 0.85,
+      reason: 'Notification permission contradicts Permissions API (headless/stealth tell)'
+    });
+  }
+
+  return detections;
+}
+
 function detectAutomation(signals) {
   const detections = [];
   const env = signals.environmental || {};
@@ -1098,6 +1131,7 @@ function runVerification(signals, ip, siteKey, userAgent, headers = {}, ja3Hash 
   detections.push(
     ...detectVisionAI(signals),
     ...detectHeadless(signals, userAgent),
+    ...detectStealthArtifacts(signals),
     ...detectAutomation(signals),
     ...detectCDP(signals),
     ...detectBehavioral(signals),

--- a/server-python/server.py
+++ b/server-python/server.py
@@ -580,6 +580,40 @@ def detect_headless(signals: Dict, user_agent: str) -> List[Detection]:
     return detections
 
 
+def detect_stealth_artifacts(signals: Dict) -> List[Detection]:
+    """Flag anti-detection patch traces collected by the client.
+
+    FALSE-POSITIVE-SAFE: a genuine browser never produces these — they are
+    internal contradictions / native-function tampering, not environment-shape
+    heuristics (which would misfire on real Linux/VPN users). Targets stealth
+    agents (e.g. Manus AI) driving real-but-patched Chromium. Only the two
+    FP-safe signals are scored; the client also collects privacy-extension-
+    ambiguous artifacts (patched_*) for observability that are intentionally NOT
+    scored. Keep in sync with server-go and server-node.
+    """
+    detections = []
+    env = signals.get("environmental", {})
+
+    # Function.prototype.toString proxied — the signature move of stealth
+    # frameworks (used to make their other native overrides look untouched).
+    artifact_signals = (env.get("stealthArtifacts") or {}).get("signals", []) or []
+    if "tostring_proxied" in artifact_signals:
+        detections.append(Detection(
+            ThreatCategory.HEADLESS, 0.9, 0.85,
+            "Function.prototype.toString is proxied (stealth automation patch)"
+        ))
+
+    # Notification.permission == "denied" while the Permissions API reports
+    # "prompt": a state a real browser cannot reach (classic headless tell).
+    if (env.get("permissionProbe") or {}).get("contradiction") is True:
+        detections.append(Detection(
+            ThreatCategory.HEADLESS, 0.85, 0.85,
+            "Notification permission contradicts Permissions API (headless/stealth tell)"
+        ))
+
+    return detections
+
+
 def detect_automation(signals: Dict) -> List[Detection]:
     detections = []
     env = signals.get("environmental", {})
@@ -1135,6 +1169,7 @@ def run_verification(
     # Behavioral detectors
     detections.extend(detect_vision_ai(signals))
     detections.extend(detect_headless(signals, user_agent))
+    detections.extend(detect_stealth_artifacts(signals))
     detections.extend(detect_automation(signals))
     detections.extend(detect_cdp(signals))
     detections.extend(detect_behavioral(signals))

--- a/test/test-detection.js
+++ b/test/test-detection.js
@@ -185,6 +185,65 @@ async function testHeadlessBrowserDetection() {
   assertDetection(noPluginsResult, 'headless', true, 'Detects no browser plugins');
 }
 
+async function testStealthArtifactDetection() {
+  log('\n[Stealth Patch Artifact Detection]', colors.cyan);
+
+  const chromeHeaders = {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    'Accept-Language': 'en-US,en;q=0.9',
+  };
+  // Benign env shared by the positive cases so the ONLY headless signal is the
+  // stealth artifact under test (avoids plugins=0 etc. firing headless too).
+  const benignEnv = {
+    automationFlags: { plugins: 3, languages: true, chrome: true },
+    webglInfo: { renderer: 'ANGLE (NVIDIA, GeForce RTX 3060 Direct3D11)' },
+  };
+
+  // Function.prototype.toString proxied -> stealth automation patch
+  const toStringResult = await makeRequest('/api/verify', {
+    headers: chromeHeaders,
+    body: { siteKey: 'test', signals: { environmental: {
+      ...benignEnv,
+      stealthArtifacts: { signals: ['tostring_proxied'] },
+    } } }
+  });
+  assertDetection(toStringResult, 'headless', true, 'Detects proxied Function.prototype.toString');
+
+  // Notification.permission "denied" vs Permissions API "prompt" -> impossible state
+  const permResult = await makeRequest('/api/verify', {
+    headers: chromeHeaders,
+    body: { siteKey: 'test', signals: { environmental: {
+      ...benignEnv,
+      permissionProbe: { supported: true, notificationPermission: 'denied', queryState: 'prompt', contradiction: true },
+    } } }
+  });
+  assertDetection(permResult, 'headless', true, 'Detects Notification/Permissions API contradiction');
+
+  // FP-safety: privacy-extension-style native patches (patched_*) and a
+  // consistent human session must NOT raise the score — these artifacts are
+  // collected for observability but intentionally never scored.
+  const privacyExtResult = await makeRequest('/api/verify', {
+    headers: chromeHeaders,
+    body: {
+      siteKey: 'test',
+      signals: {
+        environmental: {
+          ...benignEnv,
+          stealthArtifacts: { signals: ['patched_canvas_todataurl', 'patched_webgl_getparameter'] },
+          permissionProbe: { supported: true, notificationPermission: 'default', queryState: 'prompt', contradiction: false },
+        },
+        behavioral: {
+          totalPoints: 80, trajectoryLength: 350, velocityVariance: 0.8,
+          microTremorScore: 0.4, approachPoints: 20, approachDirectness: 0.6,
+          overshootCorrections: 2, directionChanges: 8, interactionDuration: 3500,
+          mouseEventRate: 45,
+        },
+      }
+    }
+  });
+  assertScore(privacyExtResult, 0, 0.3, 'Privacy-extension native patches do not raise score (FP-safe)');
+}
+
 async function testDatacenterIPDetection() {
   log('\n[Datacenter IP Detection]', colors.cyan);
 
@@ -2059,6 +2118,7 @@ async function runTests() {
   await testFormAnalysis();
   await testAdvancedDetections();
   await testPlaywrightDetection();
+  await testStealthArtifactDetection();
   await testMissingPoWHardFail();
   await testTightenedExemptions();
   await testMobileSensorDetection();


### PR DESCRIPTION
Fixes #15 — Manus AI passing the captcha.

## Root cause
Cloud AI agents (Manus) drive a **real, stealth-patched Chromium** with genuine cursor/scroll input. That silences FCaptcha's strongest discriminators at once — `webdriver`/`window.chrome` checks, CDP synthetic-input forensics, and no-mouse-movement heuristics — leaving only weak contributory IP/env signals that never reach the 0.5 block threshold. (Matches the CloakBrowser / PRD-phase-3 gap.)

## Fix — FP-safe patch-artifact detection
Detect traces a *patched* automation browser leaves that a genuine browser cannot, instead of environment-shape heuristics (Linux+Chrome+DPR1+no-touch) that would misfire on real Linux/VPN/desktop users.

Two scored signals (category `headless`, **no weight changes**):
- **`tostring_proxied`** — `Function.prototype.toString` is proxied: the signature move of stealth frameworks (override natives to spoof fingerprints, then hide the override).
- **Permission contradiction** — `Notification.permission === 'denied'` while the Permissions API reports `'prompt'`: a state a real browser cannot reach.

## False-positive guardrail
The client also collects `patched_*` artifacts (canvas/webgl/permissions native overrides) but the servers **deliberately do not score them** — privacy extensions (Brave, CanvasBlocker) patch those same natives. They ride along for the opt-in verdict logging so they can be measured on real traffic before ever acting on them.

## Scope
- `client/fcaptcha.js` — `_detectStealthArtifacts()` + async `_checkPermissionContradiction()`
- `server-go/scoring.go`, `server-node/server.js`, `server-python/server.py` — detector + pipeline wiring (kept in sync)
- `test/test-detection.js` — `testStealthArtifactDetection` (2 positive + 1 FP-safety case)

## Verification
- Go builds + `go test` pass; Node/Python/client/test syntax-clean.
- Ran the suite against a live Go server and diffed failures against a clean-HEAD worktree build: **zero regressions**; new positive tests pass; FP-safety case scores 0.265 (< 0.3).

## Honest caveat
Catches common stealth setups; a source-recompiled Chromium keeps `toString` natively native and defeats this — the durable answer there is cross-session correlation (PRD phase 5).