### PR TITLE
fix(docker): serve fcaptcha.js from the image again (#23)

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -1,0 +1,74 @@
+name: Docker image smoke test
+
+# Builds the published image and checks it actually serves what it ships.
+#
+# Issue #23: the image copied the widget to /app/static/fcaptcha.js while the
+# server only looked in client/, so /fcaptcha.js returned 404 in every release
+# for roughly three months. The file was present the whole time — nothing
+# fetched it to find out. Unit tests could not catch it because the mismatch
+# lived between the Dockerfile and the Go source, not inside either.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docker/**'
+      - 'server-go/**'
+      - 'client/**'
+      - '.github/workflows/docker-smoke.yml'
+  pull_request:
+    paths:
+      - 'docker/**'
+      - 'server-go/**'
+      - 'client/**'
+      - '.github/workflows/docker-smoke.yml'
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build the image
+        run: docker build -f docker/Dockerfile -t fcaptcha-smoke .
+
+      - name: Start it
+        run: |
+          docker run -d --name fcaptcha-smoke -p 3000:3000 fcaptcha-smoke
+          for _ in $(seq 1 40); do
+            curl -sf http://localhost:3000/health >/dev/null && exit 0
+            sleep 0.5
+          done
+          echo "container never became healthy"; docker logs fcaptcha-smoke; exit 1
+
+      - name: The widget must be served, not 404
+        run: |
+          code=$(curl -s -o /tmp/widget.js -w '%{http_code}' http://localhost:3000/fcaptcha.js)
+          if [ "$code" != "200" ]; then
+            echo "::error::/fcaptcha.js returned $code — the image ships the widget but does not serve it (see #23)"
+            docker logs fcaptcha-smoke
+            exit 1
+          fi
+          grep -q "FCaptcha" /tmp/widget.js || { echo "::error::/fcaptcha.js served something that is not the widget"; exit 1; }
+          echo "widget served, $(wc -c < /tmp/widget.js) bytes"
+
+      - name: The startup log must not warn about a missing widget
+        run: |
+          if docker logs fcaptcha-smoke 2>&1 | grep -q "will return 404"; then
+            echo "::error::server logged that it could not find the widget"
+            docker logs fcaptcha-smoke
+            exit 1
+          fi
+
+      # The demo page loads the widget from /fcaptcha.js, so it was collateral
+      # damage in #23: the page returned 200 while the widget behind it 404'd.
+      - name: The shipped demo page must load and reference a widget that exists
+        run: |
+          curl -sf http://localhost:3000/demo/ -o /tmp/demo.html || { echo "::error::/demo/ did not load"; exit 1; }
+          src=$(grep -o 'src="[^"]*fcaptcha[^"]*"' /tmp/demo.html | head -1 | sed 's/src="//;s/"//')
+          echo "demo loads the widget from: $src"
+          curl -sf "http://localhost:3000${src}" >/dev/null || { echo "::error::the demo's widget URL $src does not resolve"; exit 1; }
+
+      - name: Cleanup
+        if: always()
+        run: docker rm -f fcaptcha-smoke || true

--- a/server-go/clientpath_test.go
+++ b/server-go/clientpath_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Regression tests for #23: the Docker image copies the widget to
+// /app/static/fcaptcha.js, but resolveClientPath only probed client/ paths, so
+// /fcaptcha.js returned 404 in every published image — and the demo page the
+// image ships loads the widget from that path, so it never initialised either.
+
+func TestResolveClientPathFindsDockerLayout(t *testing.T) {
+	// Reproduce the image: a binary in /app with the widget at ./static/.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "static"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, "static", "fcaptcha.js")
+	if err := os.WriteFile(want, []byte("// widget"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(dir)
+	t.Setenv("FCAPTCHA_CLIENT_PATH", "")
+
+	got := resolveClientPath()
+	if got == "" {
+		t.Fatal("the Docker image's static/ layout was not found — /fcaptcha.js would 404")
+	}
+	if !strings.HasSuffix(got, filepath.Join("static", "fcaptcha.js")) {
+		t.Errorf("resolved %q, expected the static/ copy", got)
+	}
+}
+
+func TestResolveClientPathFindsRepoLayout(t *testing.T) {
+	// `go run .` from server-go/, i.e. the widget one level up.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "client"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "client", "fcaptcha.js"), []byte("// widget"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(dir, "server-go")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(sub)
+	t.Setenv("FCAPTCHA_CLIENT_PATH", "")
+
+	if got := resolveClientPath(); got == "" {
+		t.Error("the repo layout (../client/fcaptcha.js) was not found")
+	}
+}
+
+func TestResolveClientPathEnvOverrideWins(t *testing.T) {
+	t.Setenv("FCAPTCHA_CLIENT_PATH", "/somewhere/else/fcaptcha.js")
+	if got := resolveClientPath(); got != "/somewhere/else/fcaptcha.js" {
+		t.Errorf("the explicit override must win, got %q", got)
+	}
+}
+
+// The unit tests above cannot catch a Dockerfile that moves the file somewhere
+// new. That is what the docker-smoke CI job is for — it builds the image and
+// fetches /fcaptcha.js. This test records the coupling so anyone editing the
+// candidate list knows the Dockerfile is the other half of it.
+func TestCandidateListCoversDockerfileDestination(t *testing.T) {
+	df, err := os.ReadFile(filepath.Join("..", "docker", "Dockerfile"))
+	if err != nil {
+		t.Skipf("docker/Dockerfile not readable from here: %v", err)
+	}
+	if !strings.Contains(string(df), "./static/fcaptcha.js") {
+		t.Fatal("docker/Dockerfile no longer copies the widget to ./static/fcaptcha.js — " +
+			"update resolveClientPath's candidate list to match, or /fcaptcha.js will 404 (see #23)")
+	}
+}

--- a/server-go/main.go
+++ b/server-go/main.go
@@ -22,11 +22,23 @@ import (
 	"github.com/go-chi/cors"
 )
 
-// resolveClientPath finds client/fcaptcha.js at startup so the widget can be
-// served from the same origin as the API (matches the Node and Python servers).
-// FCAPTCHA_CLIENT_PATH wins; otherwise we probe a few sensible defaults so this
-// works for `go run .` from server-go/, a built binary alongside the repo, and
-// the Docker image (which COPYs the file to /app/client/fcaptcha.js).
+// resolveClientPath finds fcaptcha.js at startup so the widget can be served
+// from the same origin as the API (matches the Node and Python servers).
+// FCAPTCHA_CLIENT_PATH wins; otherwise probe the layouts this binary actually
+// ships in.
+//
+// The `static/` entries are load-bearing and were missing until #23. The Docker
+// image copies the widget to /app/static/fcaptcha.js — that has been its layout
+// since the image was introduced, and /demo/ is served from ./static/demo right
+// below. This function arrived three months later probing only `client/`, with a
+// comment asserting the image copied to /app/client/fcaptcha.js. It did not.
+//
+// The file was present in every published image the whole time; nothing looked
+// for it. /fcaptcha.js returned 404, and because the shipped demo page loads the
+// widget from that path, the demo in the image never initialised either.
+//
+// docker/Dockerfile and this list have to agree. There is a CI job that builds
+// the image and fetches /fcaptcha.js so they cannot drift apart again in silence.
 func resolveClientPath() string {
 	if p := os.Getenv("FCAPTCHA_CLIENT_PATH"); p != "" {
 		return p
@@ -34,12 +46,14 @@ func resolveClientPath() string {
 	candidates := []string{
 		"./client/fcaptcha.js",
 		"../client/fcaptcha.js",
+		"./static/fcaptcha.js", // docker/Dockerfile layout
 	}
 	if exe, err := os.Executable(); err == nil {
 		dir := filepath.Dir(exe)
 		candidates = append(candidates,
 			filepath.Join(dir, "client", "fcaptcha.js"),
 			filepath.Join(dir, "..", "client", "fcaptcha.js"),
+			filepath.Join(dir, "static", "fcaptcha.js"),
 		)
 	}
 	for _, c := range candidates {


### PR DESCRIPTION
Fixes #23.

## What's broken

The image copies the widget to `/app/static/fcaptcha.js`. `resolveClientPath` only probed `client/` paths, so it never found it and **`/fcaptcha.js` returned 404 on every published image**. Reproduced against the published tags:

```
1.17.0   /fcaptcha.js -> HTTP 404   warning_logged=1
1.18.0   /fcaptcha.js -> HTTP 404   warning_logged=1
1.19.0   /fcaptcha.js -> HTTP 404   warning_logged=1
```

The file was in the image the whole time. Nothing looked for it:

```
/app/static:
demo
fcaptcha.js
```

The demo page in the image loads the widget from `/fcaptcha.js`, so it was affected too.

## The fix

Three candidate paths added (`./static/fcaptcha.js` plus the executable-relative variant). Verified against a locally built image with **no configuration**:

```
/fcaptcha.js  -> HTTP 200  (118245 bytes, real widget)
/demo/        -> HTTP 200
startup log:  serving /fcaptcha.js from /app/static/fcaptcha.js
```

@pnlx's workaround (`FCAPTCHA_CLIENT_PATH=static/fcaptcha.js`) still works and is now unnecessary.

## Guarding it

Unit tests cover the Docker layout, the repo layout, the env override, and one that fails if `docker/Dockerfile` stops copying to `static/fcaptcha.js`.

But **no unit test could have caught this** — the mismatch lived *between* the Dockerfile and the Go source, not inside either. So `.github/workflows/docker-smoke.yml` now builds the image, starts it, and asserts:

- `/fcaptcha.js` returns 200 and contains the widget
- the startup log carries no "will return 404" warning
- `/demo/` loads **and its own `<script src>` resolves**

That's the check that would have caught this in February.

## Note on the other Dockerfiles

`server-node/Dockerfile` and `server-python/Dockerfile` copy only `server.js`/`server.py` without their sibling modules (`detection`, `clientip`, `limits`, `inputforensics`, …), so they can't start at all. Separate bug, not touched here — flagging it since I was in the area.
