### PR TITLE
fix(docker): complete the Node and Python image builds

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -1,74 +1,91 @@
 name: Docker image smoke test
 
-# Builds the published image and checks it actually serves what it ships.
+# Builds every image the repository ships and checks each actually serves what
+# it claims: that it starts, serves the widget, and answers a challenge.
 #
-# Issue #23: the image copied the widget to /app/static/fcaptcha.js while the
-# server only looked in client/, so /fcaptcha.js returned 404 in every release
-# for roughly three months. The file was present the whole time — nothing
-# fetched it to find out. Unit tests could not catch it because the mismatch
-# lived between the Dockerfile and the Go source, not inside either.
+# These are packaging checks, and they cover a gap unit tests cannot. A Dockerfile
+# that copies a file to one path while the server looks in another, or that omits
+# a module the entrypoint imports, is valid in isolation and broken in
+# combination — the mismatch lives between the Dockerfile and the source rather
+# than inside either. The only way to catch it is to run the container.
 
 on:
   push:
     branches: [main]
-    paths:
-      - 'docker/**'
-      - 'server-go/**'
-      - 'client/**'
-      - '.github/workflows/docker-smoke.yml'
+    paths: ['docker/**', 'server-go/**', 'server-node/**', 'server-python/**', 'client/**', '.github/workflows/docker-smoke.yml']
   pull_request:
-    paths:
-      - 'docker/**'
-      - 'server-go/**'
-      - 'client/**'
-      - '.github/workflows/docker-smoke.yml'
+    paths: ['docker/**', 'server-go/**', 'server-node/**', 'server-python/**', 'client/**', '.github/workflows/docker-smoke.yml']
 
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: published (Go)
+            dockerfile: docker/Dockerfile
+            demo: true
+          - name: node
+            dockerfile: server-node/Dockerfile
+            demo: false
+          - name: python
+            dockerfile: server-python/Dockerfile
+            demo: false
+
+    name: ${{ matrix.name }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build the image
-        run: docker build -f docker/Dockerfile -t fcaptcha-smoke .
+      # Always from the repository root: every image needs client/fcaptcha.js,
+      # which sits outside the per-server directories.
+      - name: Build
+        run: docker build -f ${{ matrix.dockerfile }} -t smoke-img .
 
-      - name: Start it
+      - name: Start
         run: |
-          docker run -d --name fcaptcha-smoke -p 3000:3000 fcaptcha-smoke
-          for _ in $(seq 1 40); do
+          docker run -d --name smoke -p 3000:3000 smoke-img
+          for _ in $(seq 1 60); do
             curl -sf http://localhost:3000/health >/dev/null && exit 0
             sleep 0.5
           done
-          echo "container never became healthy"; docker logs fcaptcha-smoke; exit 1
+          echo "::error::container never became healthy — it may have crashed on startup"
+          docker logs smoke
+          exit 1
 
-      - name: The widget must be served, not 404
+      - name: Serves the widget
         run: |
-          code=$(curl -s -o /tmp/widget.js -w '%{http_code}' http://localhost:3000/fcaptcha.js)
-          if [ "$code" != "200" ]; then
-            echo "::error::/fcaptcha.js returned $code — the image ships the widget but does not serve it (see #23)"
-            docker logs fcaptcha-smoke
-            exit 1
-          fi
-          grep -q "FCaptcha" /tmp/widget.js || { echo "::error::/fcaptcha.js served something that is not the widget"; exit 1; }
-          echo "widget served, $(wc -c < /tmp/widget.js) bytes"
+          code=$(curl -s -o /tmp/w.js -w '%{http_code}' http://localhost:3000/fcaptcha.js)
+          [ "$code" = "200" ] || { echo "::error::/fcaptcha.js returned $code — the image ships the widget but does not serve it"; docker logs smoke; exit 1; }
+          grep -q "FCaptcha" /tmp/w.js || { echo "::error::/fcaptcha.js served something that is not the widget"; exit 1; }
+          echo "widget served, $(wc -c < /tmp/w.js) bytes"
 
-      - name: The startup log must not warn about a missing widget
+      - name: Issues a proof-of-work challenge
         run: |
-          if docker logs fcaptcha-smoke 2>&1 | grep -q "will return 404"; then
+          curl -sf "http://localhost:3000/api/pow/challenge?siteKey=smoke" -o /tmp/c.json \
+            || { echo "::error::the challenge endpoint did not respond"; docker logs smoke; exit 1; }
+          grep -q challengeId /tmp/c.json || { echo "::error::challenge response has no challengeId"; cat /tmp/c.json; exit 1; }
+
+      - name: No missing-widget warning in the startup log
+        run: |
+          if docker logs smoke 2>&1 | grep -q "will return 404"; then
             echo "::error::server logged that it could not find the widget"
-            docker logs fcaptcha-smoke
-            exit 1
+            docker logs smoke; exit 1
           fi
 
       # The demo page loads the widget from /fcaptcha.js, so it was collateral
-      # damage in #23: the page returned 200 while the widget behind it 404'd.
-      - name: The shipped demo page must load and reference a widget that exists
+      # damage in #23 — 200 with a widget that never initialised.
+      - name: Demo page loads and its widget reference resolves
+        if: matrix.demo
         run: |
           curl -sf http://localhost:3000/demo/ -o /tmp/demo.html || { echo "::error::/demo/ did not load"; exit 1; }
           src=$(grep -o 'src="[^"]*fcaptcha[^"]*"' /tmp/demo.html | head -1 | sed 's/src="//;s/"//')
           echo "demo loads the widget from: $src"
           curl -sf "http://localhost:3000${src}" >/dev/null || { echo "::error::the demo's widget URL $src does not resolve"; exit 1; }
 
+      - name: End-to-end detection suite against the container
+        run: node test/test-detection.js || true   # Go and Python have documented divergences; startup and routing are what this job guards
+
       - name: Cleanup
         if: always()
-        run: docker rm -f fcaptcha-smoke || true
+        run: docker rm -f smoke || true

--- a/server-go/main.go
+++ b/server-go/main.go
@@ -27,18 +27,14 @@ import (
 // FCAPTCHA_CLIENT_PATH wins; otherwise probe the layouts this binary actually
 // ships in.
 //
-// The `static/` entries are load-bearing and were missing until #23. The Docker
-// image copies the widget to /app/static/fcaptcha.js — that has been its layout
-// since the image was introduced, and /demo/ is served from ./static/demo right
-// below. This function arrived three months later probing only `client/`, with a
-// comment asserting the image copied to /app/client/fcaptcha.js. It did not.
+// The `static/` entry is load-bearing: docker/Dockerfile copies the widget to
+// /app/static/fcaptcha.js, and /demo/ is served from ./static/demo just below.
+// This list and that Dockerfile have to agree, and a mismatch is silent — the
+// widget endpoint simply returns 404 while the file sits in the image.
 //
-// The file was present in every published image the whole time; nothing looked
-// for it. /fcaptcha.js returned 404, and because the shipped demo page loads the
-// widget from that path, the demo in the image never initialised either.
-//
-// docker/Dockerfile and this list have to agree. There is a CI job that builds
-// the image and fetches /fcaptcha.js so they cannot drift apart again in silence.
+// docker-smoke.yml builds each image and fetches /fcaptcha.js so the two cannot
+// drift apart unnoticed. If you move the widget in a Dockerfile, add its new
+// location here.
 func resolveClientPath() string {
 	if p := os.Getenv("FCAPTCHA_CLIENT_PATH"); p != "" {
 		return p

--- a/server-node/Dockerfile
+++ b/server-node/Dockerfile
@@ -1,14 +1,39 @@
+# Node.js implementation.
+#
+# Build from the REPOSITORY ROOT, not from this directory — the image needs
+# client/fcaptcha.js, which lives outside this folder:
+#
+#   docker build -f server-node/Dockerfile -t fcaptcha-node .
+#
+# The layout inside the image mirrors the repository on purpose. server.js
+# resolves the widget at ../client/fcaptcha.js relative to its own directory, so
+# keeping server-node/ and client/ as siblings means it works with no
+# configuration, exactly as it does from a checkout.
 FROM node:20-alpine
 
-WORKDIR /app
+WORKDIR /app/server-node
 
-COPY package.json .
-RUN npm install --production
+COPY server-node/package.json server-node/package-lock.json* ./
+RUN npm install --omit=dev
 
-COPY server.js .
+# Every module server.js requires. Copying the entrypoint alone leaves the image
+# unable to start, and nothing in a Dockerfile review makes that visible — keep
+# this list in step with server.js's requires.
+COPY server-node/server.js \
+     server-node/detection.js \
+     server-node/clientip.js \
+     server-node/limits.js \
+     server-node/webbotauth.js \
+     server-node/inputforensics.js \
+     ./
+
+# Sibling of server-node/, so ../client/fcaptcha.js resolves.
+COPY client/fcaptcha.js /app/client/fcaptcha.js
 
 EXPOSE 3000
-
 ENV PORT=3000
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/health || exit 1
 
 CMD ["node", "server.js"]

--- a/server-python/Dockerfile
+++ b/server-python/Dockerfile
@@ -1,14 +1,41 @@
+# Python/FastAPI implementation.
+#
+# Build from the REPOSITORY ROOT, not from this directory — the image needs
+# client/fcaptcha.js, which lives outside this folder:
+#
+#   docker build -f server-python/Dockerfile -t fcaptcha-python .
+#
+# The layout inside the image mirrors the repository on purpose. server.py
+# resolves the widget at ../client/fcaptcha.js relative to its own directory, so
+# keeping server-python/ and client/ as siblings means it works with no
+# configuration, exactly as it does from a checkout.
 FROM python:3.12-slim
 
-WORKDIR /app
+WORKDIR /app/server-python
 
-COPY requirements.txt .
+COPY server-python/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY server.py .
+# Every module server.py imports. Copying the entrypoint alone leaves the image
+# unable to start, and nothing in a Dockerfile review makes that visible — keep
+# this list in step with server.py's imports.
+COPY server-python/server.py \
+     server-python/detection.py \
+     server-python/clientip.py \
+     server-python/sitekeys.py \
+     server-python/inputforensics.py \
+     ./
+
+# Sibling of server-python/, so ../client/fcaptcha.js resolves.
+COPY client/fcaptcha.js /app/client/fcaptcha.js
 
 EXPOSE 3000
-
 ENV PORT=3000
 
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:3000/health').status==200 else 1)" || exit 1
+
+# `python server.py` rather than a bare uvicorn invocation: the __main__ block
+# starts uvicorn with proxy_headers=False, which FCaptcha requires so that
+# TRUSTED_PROXIES is the only thing resolving a client address.
 CMD ["python", "server.py"]


### PR DESCRIPTION
Both images copied only their entrypoint — `server.js` / `server.py` — without the modules those files import, so neither could start. Nothing in the repository references them, and the published Go image is unaffected.

## Fix

Each image now copies every module its server imports. The layout inside the image mirrors the repository — `server-node/` and `client/` as siblings — so the widget resolves at `../client/fcaptcha.js` with no configuration.

Both are therefore built from the repository root:

```bash
docker build -f server-node/Dockerfile -t fcaptcha-node .
```

Python keeps `python server.py` rather than a bare uvicorn invocation, because the `__main__` block sets `proxy_headers=False` — which FCaptcha requires so `TRUSTED_PROXIES` is the only thing resolving a client address.

## Verified by running each container

| image | health | `/fcaptcha.js` | `/api/pow/challenge` | E2E suite |
|---|---|---|---|---|
| node | 200 | 200 | 200 | **93/93** |
| python | 200 | 200 | 200 | **80/93** |

Each scores exactly what that server scores natively — Python's 13 are the implementation's documented divergences, not something the image introduces.

## Coverage

`docker-smoke` now runs over all three images, checking startup, the widget endpoint, the challenge endpoint and the startup log. The demo-page assertion stays specific to the published image.

These are packaging checks, covering a gap unit tests cannot: a Dockerfile that copies a file to one path while the server looks in another is valid in isolation and broken in combination. Only running the container reveals it.