### PR TITLE
Require a valid proof of work for a token, not just a good score

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -13,6 +13,7 @@ This guide covers installing and deploying FCaptcha for development and producti
 - [Docker Deployment](#docker-deployment)
 - [Production Setup](#production-setup)
 - [Configuration Reference](#configuration-reference)
+- [Upgrading to 1.23.0](#upgrading-to-1230)
 - [Upgrading to 1.22.0](#upgrading-to-1220)
 - [Verification](#verification)
 - [Troubleshooting](#troubleshooting)
@@ -568,6 +569,28 @@ startup log and the warning above rather than assuming.
 | 0.7 - 1.0 | Block | Reject request |
 
 ---
+
+## Upgrading to 1.23.0
+
+**A proof of work is now required for a token.** `/api/verify` and `/api/score`
+withhold the token when the request carries no valid PoW solution, instead of
+merely scoring it.
+
+If you use the bundled widget, nothing changes — it already solves a challenge on
+every path and aborts rather than submit without one. Verified against the
+measurement harness: human false-positive rate stays 0.00% and the human median
+score is unchanged at 0.097.
+
+If you call `/api/verify` directly from your own client, you must now complete
+the handshake: `GET /api/pow/challenge`, echo the returned nonce in
+`signals.meta.challengeNonce`, commit the signals into the PoW input, and send
+the solution as `powSolution`. A refusal reports `"reason": "pow_not_satisfied"`.
+
+Why: the final score is a weighted sum, so the `bot` category could contribute at
+most its 0.13 weight against a 0.5 threshold. Every PoW failure firing at once
+reached 0.1298 — so a bare `curl` with no solution and no signals was issued a
+valid token. There is no configuration to restore the old behaviour; it was a
+bypass, not a feature.
 
 ## Upgrading to 1.22.0
 

--- a/README.md
+++ b/README.md
@@ -455,6 +455,31 @@ Datacenter addresses, high request rates and exceeded rate limits raise the time
 floor only — never the difficulty. See [what proof of work does and does not buy
 you](#what-the-proof-of-work-does-and-does-not-buy-you) for why.
 
+### Preconditions: what a token requires beyond a good score
+
+A token is issued only when **all** of these hold. They are checked outside the
+score on purpose — a score threshold answers "how suspicious is this visitor",
+which is the wrong question to ask of a caller that never completed the
+challenge:
+
+| Precondition | `reason` when it fails |
+|---|---|
+| The score is below the success threshold (0.5) | (score speaks for itself) |
+| A **valid proof of work** for a challenge this server issued, with the signals bound to it | `pow_not_satisfied` |
+| The minting origin is permitted, if `FCAPTCHA_ALLOWED_HOSTNAMES` is set | `hostname_not_allowed` |
+
+The widget solves a proof of work on every path and aborts rather than submit
+without one, so a request that arrives without a valid solution did not come from
+the widget. Missing, forged, or unbound solutions are also `dispositive`: they
+floor the reported score at 0.9, so an integrator risk-banding on the score sees
+the same verdict the gate did.
+
+This matters more than it looks. The final score is a weighted sum across ~12
+categories, so **any one category contributes at most its own weight** — the
+`bot` category caps at 0.13 against a 0.5 threshold. Before v1.23.0 that meant a
+bare `curl` with no proof of work and no browser was issued a valid token: every
+detector fired correctly and the aggregation discarded the verdict.
+
 ### POST /api/verify
 Verify a checkbox CAPTCHA submission.
 

--- a/server-go/main.go
+++ b/server-go/main.go
@@ -380,6 +380,7 @@ type VerifyResponse struct {
 	Recommendation string             `json:"recommendation"`
 	CategoryScores map[string]float64 `json:"categoryScores,omitempty"`
 	Detections     []DetectionInfo    `json:"detections,omitempty"`
+	Reason         string             `json:"reason,omitempty"`
 }
 
 type DetectionInfo struct {
@@ -520,6 +521,7 @@ func verifyHandler(engine *ScoringEngine, trust *ProxyTrust, siteKeys *SiteKeyGu
 			Recommendation: result.Recommendation,
 			CategoryScores: result.CategoryScores,
 			Detections:     detections,
+			Reason:         result.Reason,
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -620,6 +622,9 @@ func invisibleScoreHandler(engine *ScoringEngine, trust *ProxyTrust, siteKeys *S
 			"action":         SanitizeAction(req.Action),
 			"cdata":          SanitizeCData(req.CData),
 			"recommendation": result.Recommendation,
+		}
+		if result.Reason != "" {
+			resp["reason"] = result.Reason
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/server-go/scoring.go
+++ b/server-go/scoring.go
@@ -61,6 +61,11 @@ type VerificationResult struct {
 	Detections     []DetectionResult
 	CategoryScores map[string]float64
 	Recommendation string
+	// Reason explains a token withheld for something other than the score:
+	// "pow_not_satisfied" or "hostname_not_allowed". Empty otherwise. Without it
+	// an integrator whose score is comfortably under the threshold has no way to
+	// tell why no token came back.
+	Reason string
 }
 
 // PoWChallenge for server-verified proof of work
@@ -350,11 +355,25 @@ func (e *ScoringEngine) VerifyWithHeaders(signals map[string]interface{}, ip, si
 	detections := make([]DetectionResult, 0, len(preDetections)+8)
 	detections = append(detections, preDetections...)
 
-	// Verify PoW if provided
+	// Verify PoW if provided.
+	//
+	// powSatisfied records whether the caller actually completed the challenge
+	// this server issued. It gates token issuance below rather than only feeding
+	// the score, because a proof of work is a precondition, not evidence: the
+	// widget solves one on every path and aborts rather than submit without it,
+	// so a request that arrives without a valid solution did not come from the
+	// widget at all.
+	//
+	// Scoring it alone was not enough. The final score is a weighted sum, so the
+	// bot category contributes at most its 0.13 weight — every PoW failure
+	// firing at once reached 0.1298 against a 0.5 threshold, and a bare `curl`
+	// with no solution and no signals was issued a valid token. The detections
+	// were all correct; the aggregation discarded them.
 	var pow *PoWSolution
 	if len(powSolution) > 0 {
 		pow = powSolution[0]
 	}
+	powSatisfied := false
 	if pow != nil && pow.ChallengeID != "" {
 		powResult := e.VerifyPoWSolution(pow, siteKey, pow.SignalsHash)
 		if !powResult.Valid {
@@ -363,7 +382,13 @@ func (e *ScoringEngine) VerifyWithHeaders(signals map[string]interface{}, ip, si
 				Score:      0.7,
 				Confidence: 0.8,
 				Reason:     "PoW verification failed: " + powResult.Reason,
+				// A solution that does not verify against a challenge this
+				// server issued is not weak evidence of automation, it is proof
+				// the challenge was not completed. See applyDispositiveFloor.
+				Dispositive: true,
 			})
+		} else {
+			powSatisfied = true
 		}
 
 		// Verify challenge nonce binding
@@ -373,11 +398,16 @@ func (e *ScoringEngine) VerifyWithHeaders(signals map[string]interface{}, ip, si
 				clientNonce = getString(meta, "challengeNonce")
 			}
 			if clientNonce == "" || clientNonce != powResult.Nonce {
+				// The solution verifies but the signals it commits to are not
+				// the ones presented, so the work was done for a different
+				// payload. Revokes the pass granted above.
+				powSatisfied = false
 				detections = append(detections, DetectionResult{
-					Category:   CategoryBot,
-					Score:      0.9,
-					Confidence: 0.9,
-					Reason:     "Challenge nonce mismatch (signals not bound to challenge)",
+					Category:    CategoryBot,
+					Score:       0.9,
+					Confidence:  0.9,
+					Reason:      "Challenge nonce mismatch (signals not bound to challenge)",
+					Dispositive: true,
 				})
 			}
 		}
@@ -411,10 +441,11 @@ func (e *ScoringEngine) VerifyWithHeaders(signals map[string]interface{}, ip, si
 	} else {
 		// No PoW solution provided - hard fail
 		detections = append(detections, DetectionResult{
-			Category:   CategoryBot,
-			Score:      0.9,
-			Confidence: 0.95,
-			Reason:     "No PoW solution provided",
+			Category:    CategoryBot,
+			Score:       0.9,
+			Confidence:  0.95,
+			Reason:      "No PoW solution provided",
+			Dispositive: true,
 		})
 	}
 
@@ -499,7 +530,28 @@ func (e *ScoringEngine) VerifyWithHeaders(signals map[string]interface{}, ip, si
 	// detection layer has nothing to say about it and the refusal is reported as
 	// its own reason rather than smuggled in as a bot verdict.
 	hostnameAllowed := e.allowedHostnames.Permits(hostname)
-	success := finalScore < 0.5 && hostnameAllowed
+
+	// Three independent conditions, deliberately not folded into the score.
+	//
+	// powSatisfied is the one that matters most: a score threshold answers "how
+	// suspicious is this visitor", which is the wrong question to ask of someone
+	// who never completed the challenge. Gating here means no future reweighting
+	// can reopen the bypass, and it holds even if the dispositive floor is
+	// lowered or removed.
+	success := finalScore < 0.5 && hostnameAllowed && powSatisfied
+
+	// Name the failed precondition whenever one fails, not only when the score
+	// would otherwise have allowed. Gating it on the score made the PoW case
+	// unreachable — a PoW failure is dispositive, so it floors the score at 0.9
+	// and the branch never fired — which is exactly the case a caller most needs
+	// explained.
+	withheldReason := ""
+	switch {
+	case !powSatisfied:
+		withheldReason = "pow_not_satisfied"
+	case !hostnameAllowed:
+		withheldReason = "hostname_not_allowed"
+	}
 
 	var token string
 	if success {
@@ -524,6 +576,7 @@ func (e *ScoringEngine) VerifyWithHeaders(signals map[string]interface{}, ip, si
 		Detections:     detections,
 		CategoryScores: categoryScores,
 		Recommendation: recommendation,
+		Reason:         withheldReason,
 	}
 }
 

--- a/server-go/scoring_test.go
+++ b/server-go/scoring_test.go
@@ -399,8 +399,14 @@ func TestCheckWebBotAuthEndToEnd(t *testing.T) {
 // detections (Web Bot Auth verdicts) participate in scoring rather than being
 // cosmetic — the property that makes this feature meaningful. Uses the
 // declared_ai category, which no other detector populates here, so the effect
-// is unambiguous (calculateCategoryScores is a confidence-weighted average, so
-// a detection added to an already-populated category can move it either way).
+// is unambiguous (calculateCategoryScores is a noisy-OR, so a detection added to
+// an already-populated category would be harder to attribute).
+//
+// Compares the weighted sums rather than the reported Score: neither call
+// supplies a PoW solution, so both are pinned to dispositiveFloor and the
+// reported scores are equal by construction. The floor is a separate mechanism
+// with its own tests; what is under test here is that the detection reaches the
+// sum at all.
 func TestVerifyWithHeadersScoresPreDetections(t *testing.T) {
 	e := NewScoringEngine("test-secret")
 	pre := []DetectionResult{webBotAuthVerified("https://agent.example", "thumb", "ed25519")}
@@ -414,8 +420,10 @@ func TestVerifyWithHeadersScoresPreDetections(t *testing.T) {
 	if withPre.CategoryScores["declared_ai"] <= 0 {
 		t.Errorf("expected preDetection to populate the declared_ai category score, got %v", withPre.CategoryScores["declared_ai"])
 	}
-	if withPre.Score <= base.Score {
-		t.Errorf("expected preDetection to raise the final score: base=%v withPre=%v", base.Score, withPre.Score)
+	baseSum := e.calculateFinalScore(base.CategoryScores)
+	withPreSum := e.calculateFinalScore(withPre.CategoryScores)
+	if withPreSum <= baseSum {
+		t.Errorf("expected preDetection to raise the weighted sum: base=%v withPre=%v", baseSum, withPreSum)
 	}
 	found := false
 	for _, d := range withPre.Detections {
@@ -644,5 +652,87 @@ func TestWebBotAuthLifetimeCeiling(t *testing.T) {
 	}, "https://agent.example")
 	if noTimes[0].Details["verified"] != true {
 		t.Errorf("absent timestamps should not suppress verification, got %+v", noTimes[0].Details)
+	}
+}
+
+// ---------------------------------------------------------------- PoW gating
+//
+// A proof of work is a precondition, not evidence. These guard the bypass found
+// on 2026-08-19: a bare `curl` sending `{"siteKey":"x","signals":{}}` — no
+// browser, no PoW, a curl User-Agent — was issued a valid token, ten times out
+// of ten, on every server. Every detector fired correctly; the aggregation threw
+// the verdict away, because the final score is a weighted sum and the bot
+// category contributes at most its 0.13 weight. All the PoW failures firing at
+// once reached 0.1298 against a 0.5 threshold.
+
+// noPoWVerify runs a verification the way the bypass did: no PoW solution at all.
+func noPoWVerify(e *ScoringEngine, signals map[string]interface{}) *VerificationResult {
+	return e.VerifyWithHeaders(signals, "203.0.113.4", "site", "curl/8.7.1", nil, "", "", false, nil, TokenBinding{})
+}
+
+func TestNoPoWSolutionWithholdsAToken(t *testing.T) {
+	e := NewScoringEngine("test-secret")
+	result := noPoWVerify(e, map[string]interface{}{})
+
+	if result.Success {
+		t.Error("a request with no PoW solution must not succeed")
+	}
+	if result.Token != "" {
+		t.Error("a request with no PoW solution must not be issued a token")
+	}
+}
+
+func TestNoPoWSolutionIsDispositive(t *testing.T) {
+	// The gate withholds the token; the floor makes the reported score honest,
+	// so an integrator risk-banding on the score sees the truth too.
+	e := NewScoringEngine("test-secret")
+	result := noPoWVerify(e, map[string]interface{}{})
+
+	if result.Score < dispositiveFloor {
+		t.Errorf("expected the dispositive floor, got %v", result.Score)
+	}
+	if result.Recommendation != "block" {
+		t.Errorf("expected a block recommendation, got %q", result.Recommendation)
+	}
+}
+
+func TestForgedPoWSolutionWithholdsAToken(t *testing.T) {
+	// A solution referencing a challenge this server never issued.
+	e := NewScoringEngine("test-secret")
+	forged := &PoWSolution{ChallengeID: "forged", Nonce: 1, Hash: "0000deadbeef", SignalsHash: "x"}
+	result := e.VerifyWithHeaders(map[string]interface{}{}, "203.0.113.4", "site", "curl/8.7.1", nil, "", "", false, nil, TokenBinding{}, forged)
+
+	if result.Success || result.Token != "" {
+		t.Error("a forged PoW solution must not be issued a token")
+	}
+	if result.Score < dispositiveFloor {
+		t.Errorf("expected the dispositive floor, got %v", result.Score)
+	}
+}
+
+func TestWithheldTokenReportsWhy(t *testing.T) {
+	// A caller whose score is under the threshold but who gets no token needs to
+	// be told which precondition failed, or the failure is unsupportable.
+	e := NewScoringEngine("test-secret")
+	result := noPoWVerify(e, map[string]interface{}{})
+	if result.Reason != "" && result.Reason != "pow_not_satisfied" {
+		t.Errorf("unexpected reason %q", result.Reason)
+	}
+}
+
+func TestBotCategoryAloneCannotReachTheThreshold(t *testing.T) {
+	// Pins the reason the gate has to exist rather than trusting the score.
+	// If this ever fails because the weighted sum was replaced, revisit whether
+	// the gate is still the right mechanism — but do not remove it on the
+	// strength of a reweighting alone.
+	e := NewScoringEngine("test-secret")
+	saturated := map[string]float64{}
+	for cat := range e.weights {
+		saturated[string(cat)] = 0.0
+	}
+	saturated[string(CategoryBot)] = 1.0
+
+	if got := e.calculateFinalScore(saturated); got >= 0.5 {
+		t.Errorf("bot category alone now reaches %v; the weighting changed", got)
 	}
 }

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -1350,6 +1350,19 @@ function runVerification(signals, ip, siteKey, userAgent, headers = {}, ja3Hash 
 
   // Verify PoW if provided
   let powValid = false;
+  // powSatisfied records whether the caller actually completed the challenge
+  // this server issued. It gates token issuance below rather than only feeding
+  // the score, because a proof of work is a precondition, not evidence: the
+  // widget solves one on every path and aborts rather than submit without it,
+  // so a request that arrives without a valid solution did not come from the
+  // widget at all.
+  //
+  // Scoring it alone was not enough. The final score is a weighted sum, so the
+  // bot category contributes at most its 0.13 weight — every PoW failure firing
+  // at once reached 0.1298 against a 0.5 threshold, and a bare `curl` with no
+  // solution and no signals was issued a valid token. The detections were all
+  // correct; the aggregation discarded them.
+  let powSatisfied = false;
   let powVerification = null;
   if (powSolution && powSolution.challengeId) {
     powVerification = powChallengeStore.verify(
@@ -1366,19 +1379,30 @@ function runVerification(signals, ip, siteKey, userAgent, headers = {}, ja3Hash 
         category: 'bot',
         score: 0.7,
         confidence: 0.8,
-        reason: `PoW verification failed: ${powVerification.reason}`
+        reason: `PoW verification failed: ${powVerification.reason}`,
+        // A solution that does not verify against a challenge this server
+        // issued is not weak evidence of automation, it is proof the challenge
+        // was not completed. See DISPOSITIVE_FLOOR.
+        dispositive: true
       });
+    } else {
+      powSatisfied = true;
     }
 
     // Verify challenge nonce binding
     if (powValid && powVerification.nonce) {
       const clientNonce = signals.meta?.challengeNonce;
       if (!clientNonce || clientNonce !== powVerification.nonce) {
+        // The solution verifies but the signals it commits to are not the ones
+        // presented, so the work was done for a different payload. Revokes the
+        // pass granted above.
+        powSatisfied = false;
         detections.push({
           category: 'bot',
           score: 0.9,
           confidence: 0.9,
-          reason: 'Challenge nonce mismatch (signals not bound to challenge)'
+          reason: 'Challenge nonce mismatch (signals not bound to challenge)',
+          dispositive: true
         });
       }
     }
@@ -1410,7 +1434,8 @@ function runVerification(signals, ip, siteKey, userAgent, headers = {}, ja3Hash 
       category: 'bot',
       score: 0.9,
       confidence: 0.95,
-      reason: 'No PoW solution provided'
+      reason: 'No PoW solution provided',
+      dispositive: true
     });
   }
 
@@ -1500,7 +1525,24 @@ function runVerification(signals, ip, siteKey, userAgent, headers = {}, ja3Hash 
   // detection layer has nothing to say about it and the refusal is reported as
   // its own reason rather than smuggled in as a bot verdict.
   const hostnameAllowed = ALLOWED_HOSTNAMES.permits(hostname);
-  const success = finalScore < 0.5 && hostnameAllowed;
+
+  // Three independent conditions, deliberately not folded into the score.
+  //
+  // powSatisfied is the one that matters most: a score threshold answers "how
+  // suspicious is this visitor", which is the wrong question to ask of someone
+  // who never completed the challenge. Gating here means no future reweighting
+  // can reopen the bypass, and it holds even if the dispositive floor is
+  // lowered or removed.
+  const success = finalScore < 0.5 && hostnameAllowed && powSatisfied;
+
+  // Name the failed precondition whenever one fails, not only when the score
+  // would otherwise have allowed. Gating it on the score made the PoW case
+  // unreachable — a PoW failure is dispositive, so it floors the score at 0.9
+  // and the branch never fired — which is exactly the case a caller most needs
+  // explained.
+  let withheldReason = '';
+  if (!powSatisfied) withheldReason = 'pow_not_satisfied';
+  else if (!hostnameAllowed) withheldReason = 'hostname_not_allowed';
 
   const token = success
     ? generateToken(ip, siteKey, finalScore, {
@@ -1522,7 +1564,8 @@ function runVerification(signals, ip, siteKey, userAgent, headers = {}, ja3Hash 
     recommendation,
     categoryScores,
     detections,
-    ...(hostnameAllowed ? {} : { reason: 'hostname_not_allowed', hostname })
+    ...(withheldReason ? { reason: withheldReason } : {}),
+    ...(hostnameAllowed ? {} : { hostname })
   };
 }
 

--- a/server-python/server.py
+++ b/server-python/server.py
@@ -1462,22 +1462,47 @@ def run_verification(
             "difficulty": pow_timing.difficulty
         }
 
-    # Verify PoW if provided
+    # Verify PoW if provided.
+    #
+    # pow_satisfied records whether the caller actually completed the challenge
+    # this server issued. It gates token issuance below rather than only feeding
+    # the score, because a proof of work is a precondition, not evidence: the
+    # widget solves one on every path and aborts rather than submit without it,
+    # so a request that arrives without a valid solution did not come from the
+    # widget at all.
+    #
+    # Scoring it alone was not enough. The final score is a weighted sum, so the
+    # bot category contributes at most its 0.13 weight - every PoW failure firing
+    # at once reached 0.1298 against a 0.5 threshold, and a bare `curl` with no
+    # solution and no signals was issued a valid token. The detections were all
+    # correct; the aggregation discarded them.
+    pow_satisfied = False
     if pow_solution:
         pow_result = pow_store.verify(pow_solution, site_key, client_signals_hash)
         if not pow_result["valid"]:
             detections.append(Detection(
                 ThreatCategory.BOT, 0.7, 0.8,
-                f"PoW verification failed: {pow_result['reason']}"
+                f"PoW verification failed: {pow_result['reason']}",
+                # A solution that does not verify against a challenge this
+                # server issued is not weak evidence of automation, it is proof
+                # the challenge was not completed. See apply_dispositive_floor.
+                dispositive=True
             ))
+        else:
+            pow_satisfied = True
 
         # Verify challenge nonce binding
         if pow_result["valid"] and pow_result.get("nonce"):
             client_nonce = signals.get("meta", {}).get("challengeNonce")
             if not client_nonce or client_nonce != pow_result["nonce"]:
+                # The solution verifies but the signals it commits to are not
+                # the ones presented, so the work was done for a different
+                # payload. Revokes the pass granted above.
+                pow_satisfied = False
                 detections.append(Detection(
                     ThreatCategory.BOT, 0.9, 0.9,
-                    "Challenge nonce mismatch (signals not bound to challenge)"
+                    "Challenge nonce mismatch (signals not bound to challenge)",
+                    dispositive=True
                 ))
 
         # Server-side timing, the one cost an attacker cannot buy their way out
@@ -1506,7 +1531,8 @@ def run_verification(
         # No PoW solution provided - hard fail
         detections.append(Detection(
             ThreatCategory.BOT, 0.9, 0.95,
-            "No PoW solution provided"
+            "No PoW solution provided",
+            dispositive=True
         ))
 
     # Behavioral detectors
@@ -1604,7 +1630,26 @@ def run_verification(
     # detection layer has nothing to say about it and the refusal is reported as
     # its own reason rather than smuggled in as a bot verdict.
     hostname_allowed = ALLOWED_HOSTNAMES.permits(hostname)
-    success = final_score < 0.5 and hostname_allowed
+
+    # Three independent conditions, deliberately not folded into the score.
+    #
+    # pow_satisfied is the one that matters most: a score threshold answers "how
+    # suspicious is this visitor", which is the wrong question to ask of someone
+    # who never completed the challenge. Gating here means no future reweighting
+    # can reopen the bypass, and it holds even if the dispositive floor is
+    # lowered or removed.
+    success = final_score < 0.5 and hostname_allowed and pow_satisfied
+
+    # Name the failed precondition whenever one fails, not only when the score
+    # would otherwise have allowed. Gating it on the score made the PoW case
+    # unreachable - a PoW failure is dispositive, so it floors the score at 0.9
+    # and the branch never fired - which is exactly the case a caller most needs
+    # explained.
+    withheld_reason = ""
+    if not pow_satisfied:
+        withheld_reason = "pow_not_satisfied"
+    elif not hostname_allowed:
+        withheld_reason = "hostname_not_allowed"
 
     token = generate_token(ip, site_key, final_score, {
         "hostname": hostname,
@@ -1622,7 +1667,8 @@ def run_verification(
         "token": token,
         "timestamp": int(time.time()),
         "recommendation": recommendation,
-        **({} if hostname_allowed else {"reason": "hostname_not_allowed", "hostname": hostname}),
+        **({"reason": withheld_reason} if withheld_reason else {}),
+        **({} if hostname_allowed else {"hostname": hostname}),
         "categoryScores": category_scores,
         "detections": [
             {

--- a/server-python/test_detection.py
+++ b/server-python/test_detection.py
@@ -16,6 +16,8 @@ from server import (
     ThreatCategory,
     apply_dispositive_floor,
     calculate_category_scores,
+    calculate_final_score,
+    run_verification,
     DISPOSITIVE_FLOOR,
 )
 
@@ -108,6 +110,59 @@ def dispositive_floor():
 
     # The floor raises, never lowers.
     assert apply_dispositive_floor(0.97, declared) == 0.97
+
+
+# ------------------------------------------------------------- PoW gating
+#
+# A proof of work is a precondition, not evidence. These guard the bypass found
+# on 2026-08-19: a bare `curl` sending {"siteKey": "x", "signals": {}} - no
+# browser, no PoW, a curl User-Agent - was issued a valid token, ten times out of
+# ten, on every server. Every detector fired correctly; the aggregation threw the
+# verdict away, because the final score is a weighted sum and the bot category
+# contributes at most its 0.13 weight. All the PoW failures firing at once
+# reached 0.1298 against a 0.5 threshold.
+
+
+def _no_pow_verification(signals=None):
+    """A verification the way the bypass ran it: no PoW solution at all."""
+    return run_verification(
+        signals if signals is not None else {},
+        "203.0.113.4",
+        "site",
+        "curl/8.7.1",
+    )
+
+
+@test
+def no_pow_solution_withholds_a_token():
+    result = _no_pow_verification()
+    assert result["success"] is False, "a request with no PoW must not succeed"
+    assert not result["token"], "a request with no PoW must not be issued a token"
+
+
+@test
+def no_pow_solution_is_dispositive():
+    """The gate withholds the token; the floor makes the reported score honest,
+    so an integrator risk-banding on the score sees the truth too."""
+    result = _no_pow_verification()
+    assert result["score"] >= DISPOSITIVE_FLOOR, result["score"]
+    assert result["recommendation"] == "block", result["recommendation"]
+
+
+@test
+def withheld_token_names_the_failed_precondition():
+    result = _no_pow_verification()
+    assert result.get("reason") == "pow_not_satisfied", result.get("reason")
+
+
+@test
+def bot_category_alone_cannot_reach_the_threshold():
+    """Pins the reason the gate has to exist rather than trusting the score. If
+    this ever fails because the weighted sum was replaced, revisit whether the
+    gate is still the right mechanism - but do not remove it on the strength of a
+    reweighting alone."""
+    saturated = {ThreatCategory.BOT.value: 1.0}
+    assert calculate_final_score(saturated) < 0.5, calculate_final_score(saturated)
 
 
 DetectionTests = test.testcase("DetectionTests")

--- a/test/test-detection.js
+++ b/test/test-detection.js
@@ -58,6 +58,36 @@ async function makeRequest(endpoint, options = {}) {
   }
 }
 
+// A verification that completes the real challenge handshake: fetch a challenge,
+// stamp its nonce into signals.meta, commit the signals into the PoW input,
+// solve, and wait out the server's timing floor.
+//
+// Needed because a proof of work is now a precondition for a token rather than
+// one more scored signal. A payload posted without one is dispositively a
+// non-browser, so it floors at 0.9 no matter how human the rest of it looks —
+// which is correct, and which makes "a legitimate visitor scores low" impossible
+// to assert without modelling a legitimate visitor properly.
+//
+// Detection-only assertions deliberately keep using makeRequest: they ask
+// whether a payload trips a given detector, and that answer does not depend on
+// the handshake. Only the tests that assert on the final score need this.
+//
+// Reuses the bench harness's solver rather than carrying a second copy of the
+// scheme; it depends on nothing outside Node's crypto module.
+const { buildVerifyBody } = require('../bench/lib/pow.js');
+
+async function makeVerifiedRequest(options = {}) {
+  const requested = options.body || {};
+  const siteKey = requested.siteKey || 'test-site-key';
+  const { body } = await buildVerifyBody(
+    SERVER_URL,
+    siteKey,
+    requested.signals || {},
+    options.headers || {}
+  );
+  return makeRequest('/api/verify', { ...options, body: { ...requested, ...body } });
+}
+
 function assertDetection(result, category, shouldDetect, testName) {
   const detections = result.detections || [];
   const hasCategory = detections.some(d => d.category === category);
@@ -231,7 +261,7 @@ async function testStealthArtifactDetection() {
   // FP-safety: privacy-extension-style native patches (patched_*) and a
   // consistent human session must NOT raise the score — these artifacts are
   // collected for observability but intentionally never scored.
-  const privacyExtResult = await makeRequest('/api/verify', {
+  const privacyExtResult = await makeVerifiedRequest({
     headers: chromeHeaders,
     body: {
       siteKey: 'test',
@@ -314,7 +344,7 @@ async function testHeaderAnalysis() {
   assertDetection(badLangResult, 'bot', true, 'Detects invalid Accept-Language');
 
   // Good headers (should have low score)
-  const goodHeadersResult = await makeRequest('/api/verify', {
+  const goodHeadersResult = await makeVerifiedRequest({
     headers: {
       'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36',
       'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
@@ -395,7 +425,7 @@ async function testBrowserConsistency() {
   assertDetection(noTouchResult, 'bot', true, 'Detects mobile UA without touch support');
 
   // Consistent browser (should pass)
-  const consistentResult = await makeRequest('/api/verify', {
+  const consistentResult = await makeVerifiedRequest({
     headers: {
       'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36',
       'Accept-Language': 'en-US,en;q=0.9',
@@ -453,7 +483,7 @@ async function testBehavioralSignals() {
   assertScore(botBehaviorResult, 0.3, 1.0, 'Bot-like behavior gets high score');
 
   // Human-like behavior
-  const humanBehaviorResult = await makeRequest('/api/verify', {
+  const humanBehaviorResult = await makeVerifiedRequest({
     headers: {
       'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0',
       'Accept-Language': 'en-US,en;q=0.9',
@@ -686,7 +716,7 @@ async function testFormAnalysis() {
   assertDetection(fastTypingResult, 'bot', true, 'Detects impossibly fast textarea typing');
 
   // Test legitimate form submission
-  const legitimateResult = await makeRequest('/api/verify', {
+  const legitimateResult = await makeVerifiedRequest({
     headers: {
       'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0',
       'Accept-Language': 'en-US,en;q=0.9',
@@ -762,7 +792,7 @@ async function testKeystrokeCadence() {
   { let s = 42; function r() { s = (s * 1103515245 + 12345) & 0x7fffffff; return s / 0x7fffffff; }
     for (let i = 0; i < 30; i++) humanDwellTimes.push(25 + r() * 50); }
 
-  const humanCadenceResult = await makeRequest('/api/verify', {
+  const humanCadenceResult = await makeVerifiedRequest({
     headers: {
       'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0',
       'Accept-Language': 'en-US,en;q=0.9',
@@ -965,8 +995,9 @@ async function testKeystrokeCadence() {
 async function testTokenVerification() {
   log('\n[Token Verification]', colors.cyan);
 
-  // First get a valid token
-  const verifyResult = await makeRequest('/api/verify', {
+  // First get a valid token. Must complete the real handshake: a token is only
+  // issued to a caller that solved the challenge.
+  const verifyResult = await makeVerifiedRequest({
     headers: {
       'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0',
       'Accept-Language': 'en-US,en;q=0.9',
@@ -1243,7 +1274,7 @@ async function testAdvancedDetections() {
   assertDetection(zeroDOMRectResult, 'headless', true, 'Detects zero-dimension DOMRect');
 
   // Test legitimate advanced signals (should pass)
-  const legitimateAdvancedResult = await makeRequest('/api/verify', {
+  const legitimateAdvancedResult = await makeVerifiedRequest({
     headers: {
       'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0',
       'Accept-Language': 'en-US,en;q=0.9',
@@ -1460,6 +1491,45 @@ async function testMissingPoWHardFail() {
 
   // Score should be higher than before (0.135 from bot alone)
   assertScore(noPoWResult, 0.1, 1.0, 'Missing PoW raises score significantly');
+
+  // The bypass found on 2026-08-19: this exact request — no PoW, no browser —
+  // was issued a valid token, because the bot category contributes at most its
+  // 0.13 weight to a 0.5 threshold no matter how conclusive the evidence. A
+  // proof of work is now a precondition, checked outside the score.
+  if (!noPoWResult.token && noPoWResult.success === false) {
+    passed++;
+    log(`  ✓ Missing PoW is refused a token outright`, colors.green);
+  } else {
+    failed++;
+    log(`  ✗ Missing PoW was issued a token (score ${noPoWResult.score})`, colors.red);
+  }
+
+  if (noPoWResult.reason === 'pow_not_satisfied') {
+    passed++;
+    log(`  ✓ Refusal names the failed precondition`, colors.green);
+  } else {
+    failed++;
+    log(`  ✗ Expected reason 'pow_not_satisfied', got '${noPoWResult.reason}'`, colors.red);
+  }
+
+  // A solution referencing a challenge the server never issued must fare no
+  // better than sending none at all.
+  const forgedPoW = await makeRequest('/api/verify', {
+    headers: { 'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0' },
+    body: {
+      siteKey: 'test-site-key',
+      signals: { behavioral: { totalPoints: 80, trajectoryLength: 350, approachPoints: 12 } },
+      powSolution: { challengeId: 'forged', nonce: 1, hash: '0000deadbeef', signalsHash: 'x' },
+    },
+  });
+
+  if (!forgedPoW.token && forgedPoW.success === false) {
+    passed++;
+    log(`  ✓ Forged PoW is refused a token outright`, colors.green);
+  } else {
+    failed++;
+    log(`  ✗ Forged PoW was issued a token (score ${forgedPoW.score})`, colors.red);
+  }
 }
 
 async function testTightenedExemptions() {
@@ -1711,7 +1781,7 @@ async function testGenuineBrowserArtifacts() {
   // absent on any page without a matching externally_connectable extension.
   // Both were being reported as Playwright artifacts and scored, so an ordinary
   // Chrome visitor carried a headless-category score of 0.771.
-  const realChrome = await makeRequest('/api/verify', {
+  const realChrome = await makeVerifiedRequest({
     headers: {
       'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36',
       'Accept-Language': 'en-US,en;q=0.9', 'Accept-Encoding': 'gzip, deflate, br',


### PR DESCRIPTION
A bare `curl` was issued a valid token — ten times out of ten, on all three servers:

```
$ curl -X POST /api/verify -d '{"siteKey":"demo-site-key","signals":{}}'
tokens minted: 10 / 10
```

No browser, no proof of work, a curl User-Agent, empty signals. Every token passed `siteverify`. Reproduced against v1.21.0, so it predates the siteverify work.

## Why the detectors did not stop it

They fired. A forged solution referencing a challenge that was never issued produced seven detections and still scored **0.4003**, under the 0.5 success threshold.

`calculateFinalScore` is a weighted sum, so a category contributes at most its own weight however conclusive it is. `bot` is weighted 0.13; every PoW failure firing at once reaches 0.9986 under noisy-OR, which is **0.1298** of the final score — 0.37 short, permanently. `dispositiveFloor`'s own doc comment diagnoses this exact failure, but the mark had only been applied to `navigator.webdriver` and the ChromeDriver/Puppeteer globals, never to the proof of work — whose own code comment reads "hard fail".

## The fix

- **A proof of work is a precondition**, checked outside the score: `success = score < 0.5 && hostnameAllowed && powSatisfied`. Gating here means no future reweighting can reopen it, and it holds even if the dispositive floor is lowered.
- **The three PoW failures are marked `Dispositive`** (absent, unverifiable, nonce-unbound), so the reported score is honest too — 0.9 rather than 0.4.
- Refusals name the failed precondition (`pow_not_satisfied` / `hostname_not_allowed`) via a `reason` field.

## No effect on legitimate traffic

The widget already solves a challenge on every path and aborts rather than submit without one. Measured on the bench harness, which completes the real handshake:

| | before | after |
|---|---|---|
| human FPR | 0.00% (0/126) | 0.00% (0/126) |
| human median score | 0.097 | 0.097 |
| agent TPR | 97.33% | 97.33% |
| `curl` bulk-mint | 10/10 tokens | **0/10 tokens** |

Bench gate exits 0.

## Tests

E2E suite's eight "gets low score" assertions posted no PoW and so floored at 0.9; they now complete the real handshake via a helper that reuses the bench solver rather than duplicating the scheme. Detection-only assertions still skip it — whether a payload trips a detector does not depend on the handshake. 104 → 107 assertions, all passing on Node.

Go and Python regression tests cover a withheld token, the dispositive floor, a forged solution, the reported reason, and — pinning why the gate must exist — that the `bot` category alone cannot reach the threshold.

The 5 Go / 13 Python E2E failures are the documented pre-existing divergences, verified identical against the pre-change build.

## Breaking

Anyone calling `/api/verify` directly from a custom client must now complete the handshake. There is no flag to restore the old behaviour — it was a bypass, not a feature. See [Upgrading to 1.23.0](INSTALLATION.md#upgrading-to-1230).