### PR TITLE
Localize the widget into 34 languages, and give it an accessible name

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -45,6 +45,26 @@ jobs:
       - name: End-to-end detection suite
         run: node test/test-detection.js
 
+      # The widget in a real browser: the proof-of-work solver, and everything
+      # about localization that is DOM-shaped rather than string-shaped (whether
+      # <html lang> is consulted, whether dir="rtl" lands, whether the checkbox
+      # resolves an accessible name).
+      #
+      # These existed but ran nowhere, so an assertion that a Playwright-driven
+      # Chromium receives a token survived the shipping of the dispositive floor
+      # that correctly stops exactly that. Untested tests rot quietly.
+      - name: Install browser test dependencies
+        working-directory: test/browser
+        run: npm install --no-audit --no-fund
+
+      - name: Install Chromium
+        working-directory: test/browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Browser suite
+        working-directory: test/browser
+        run: npm test
+
       # The harness itself, before it is trusted to measure anything. Sample
       # addresses have to stay unique or every per-source measurement is taken
       # against manufactured IP sharing.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ FCaptcha is a modern CAPTCHA system designed to detect everything: traditional b
 - **Proof of Work** - Server-verified SHA-256 hashcash with 256-bit HMAC signing, per-challenge nonces, and signal commitment that binds the challenge to the collected signals. A liveness and timing gate rather than a cost function — see [what it does and does not buy you](#what-the-proof-of-work-does-and-does-not-buy-you)
 - **Comprehensive bot detection** - Headless browsers, WebDriver, Puppeteer, Playwright, Selenium, plus CDP console-attach detection
 - **Behavioral biometrics** - 40+ signals including micro-tremor, velocity/acceleration curves, trajectory analysis, coalesced pointer events, and teleport-click detection
+- **Localized** - The widget ships 34 languages with automatic detection from `<html lang>` or the browser, right-to-left layout for Arabic/Hebrew/Persian, and a `strings` override for anything not bundled
 - **Mobile-native** - Touch kinematics and passive device-sensor entropy, with accessibility exemptions for keyboard-only and touch users
 - **TLS fingerprinting** - JA3 (client-supplied) and JA4 (un-spoofable, from a trusted reverse proxy) matched against known automation tools
 - **Credential stuffing protection** - Form interaction analysis, timing, and programmatic submit/fill detection
@@ -112,6 +113,55 @@ FCAPTCHA_SECRET=your-secret node server.js
   });
 </script>
 ```
+
+**Language**
+
+The widget picks a language automatically: an explicit `lang` option, else
+`data-lang` on the container, else the page's `<html lang>`, else the browser's
+`navigator.language`, else English. The page outranks the browser deliberately —
+a widget should match the form around it rather than the reader's locale.
+
+```html
+<!-- nothing to configure: inherits from the page -->
+<html lang="de"> … <div id="captcha"></div>
+
+<!-- or state it -->
+<script>FCaptcha.render('captcha', { siteKey, lang: 'ja' });</script>
+
+<!-- or per element, for the auto-rendered form -->
+<div data-fcaptcha="your-site-key" data-lang="pt-BR"></div>
+
+<!-- or site-wide -->
+<script>FCaptcha.configure({ serverUrl: '…', lang: 'fr' });</script>
+```
+
+Region tags fall back to their base language, so `de-AT` resolves to `de`;
+`pt-BR` and `zh-TW` have their own entries where the wording differs. Arabic,
+Hebrew and Persian render right-to-left.
+
+Shipped: `ar bg ca cs da de el en es fa fi fr he hi hu id it ja ko ms nb nl pl
+pt pt-BR ro ru sk sv th tr uk vi zh-CN zh-TW` — `FCaptcha.languages()` returns
+the live list.
+
+Not on the list, or want different wording? Override any of the five strings —
+no fork required:
+
+```js
+FCaptcha.render('captcha', {
+  siteKey,
+  lang: 'is',
+  strings: {
+    label: 'Ég er ekki vélmenni',
+    verifying: 'Staðfesti…',
+    verified: 'Staðfest',
+    failed: 'Staðfesting mistókst',
+    retry: 'Staðfesting mistókst. Reyndu aftur.',
+  },
+});
+```
+
+Overrides are HTML-escaped, so a string coming from a CMS or locale file cannot
+turn the widget into an injection point.
 
 **Invisible Mode (Zero-Click)**
 

--- a/client/fcaptcha.js
+++ b/client/fcaptcha.js
@@ -16,7 +16,170 @@
     version: '1.23.0',
     widgets: new Map(),
     serverUrl: null,
+    // Site-wide language default. Per-widget `lang` still wins; leaving both
+    // unset detects from the page and then the browser.
+    lang: null,
   };
+
+  // ============================================================
+  // Localization
+  // ============================================================
+
+  /**
+   * The widget's entire user-facing vocabulary: five strings.
+   *
+   * Bundled rather than fetched. The widget is a security control on someone
+   * else's login form — a runtime request for a language pack would be another
+   * origin to trust, another thing to fail closed on a flaky network, and a
+   * render delay on the critical path. Thirty-four languages of five short
+   * strings costs about 3 KB before compression, which is not a trade worth
+   * agonising over.
+   *
+   * Keys, and where each appears:
+   *   label     the resting state, next to the checkbox
+   *   verifying while signals are collected and the proof of work is solved
+   *   verified  the success state
+   *   failed    a rejected verification
+   *   retry     a verification that errored, where retrying is the advice
+   *
+   * Region tags appear only where the wording genuinely differs (pt-BR vs pt,
+   * zh-CN vs zh-TW). Everything else resolves by base language, so `de-AT` and
+   * `de-CH` both land on `de` rather than needing their own entry.
+   */
+  const I18N = {
+    en:      ["I'm not a robot", 'Verifying…', 'Verified', 'Verification failed', 'Verification failed. Please try again.'],
+    es:      ['No soy un robot', 'Verificando…', 'Verificado', 'Error de verificación', 'Error de verificación. Inténtalo de nuevo.'],
+    pt:      ['Não sou um robô', 'A verificar…', 'Verificado', 'Falha na verificação', 'Falha na verificação. Tente novamente.'],
+    'pt-br': ['Não sou um robô', 'Verificando…', 'Verificado', 'Falha na verificação', 'Falha na verificação. Tente novamente.'],
+    fr:      ['Je ne suis pas un robot', 'Vérification…', 'Vérifié', 'Échec de la vérification', 'Échec de la vérification. Veuillez réessayer.'],
+    de:      ['Ich bin kein Roboter', 'Überprüfung…', 'Bestätigt', 'Überprüfung fehlgeschlagen', 'Überprüfung fehlgeschlagen. Bitte erneut versuchen.'],
+    it:      ['Non sono un robot', 'Verifica in corso…', 'Verificato', 'Verifica non riuscita', 'Verifica non riuscita. Riprova.'],
+    nl:      ['Ik ben geen robot', 'Verifiëren…', 'Geverifieerd', 'Verificatie mislukt', 'Verificatie mislukt. Probeer het opnieuw.'],
+    pl:      ['Nie jestem robotem', 'Weryfikacja…', 'Zweryfikowano', 'Weryfikacja nie powiodła się', 'Weryfikacja nie powiodła się. Spróbuj ponownie.'],
+    ru:      ['Я не робот', 'Проверка…', 'Проверено', 'Ошибка проверки', 'Ошибка проверки. Попробуйте ещё раз.'],
+    uk:      ['Я не робот', 'Перевірка…', 'Перевірено', 'Помилка перевірки', 'Помилка перевірки. Спробуйте ще раз.'],
+    tr:      ['Ben robot değilim', 'Doğrulanıyor…', 'Doğrulandı', 'Doğrulama başarısız', 'Doğrulama başarısız. Lütfen tekrar deneyin.'],
+    ar:      ['لست روبوتًا', 'جارٍ التحقق…', 'تم التحقق', 'فشل التحقق', 'فشل التحقق. يرجى المحاولة مرة أخرى.'],
+    he:      ['אני לא רובוט', 'מאמת…', 'אומת', 'האימות נכשל', 'האימות נכשל. נסו שוב.'],
+    fa:      ['من ربات نیستم', 'در حال تأیید…', 'تأیید شد', 'تأیید ناموفق بود', 'تأیید ناموفق بود. لطفاً دوباره تلاش کنید.'],
+    hi:      ['मैं रोबोट नहीं हूँ', 'सत्यापित किया जा रहा है…', 'सत्यापित', 'सत्यापन विफल', 'सत्यापन विफल। कृपया पुनः प्रयास करें।'],
+    id:      ['Saya bukan robot', 'Memverifikasi…', 'Terverifikasi', 'Verifikasi gagal', 'Verifikasi gagal. Silakan coba lagi.'],
+    ms:      ['Saya bukan robot', 'Mengesahkan…', 'Disahkan', 'Pengesahan gagal', 'Pengesahan gagal. Sila cuba lagi.'],
+    th:      ['ฉันไม่ใช่โปรแกรมอัตโนมัติ', 'กำลังยืนยัน…', 'ยืนยันแล้ว', 'การยืนยันล้มเหลว', 'การยืนยันล้มเหลว โปรดลองอีกครั้ง'],
+    vi:      ['Tôi không phải là người máy', 'Đang xác minh…', 'Đã xác minh', 'Xác minh thất bại', 'Xác minh thất bại. Vui lòng thử lại.'],
+    ja:      ['私はロボットではありません', '確認中…', '確認済み', '確認に失敗しました', '確認に失敗しました。もう一度お試しください。'],
+    ko:      ['로봇이 아닙니다', '확인 중…', '확인됨', '확인 실패', '확인에 실패했습니다. 다시 시도해 주세요.'],
+    'zh-cn': ['我不是机器人', '正在验证…', '已验证', '验证失败', '验证失败，请重试。'],
+    'zh-tw': ['我不是機器人', '驗證中…', '已驗證', '驗證失敗', '驗證失敗，請重試。'],
+    sv:      ['Jag är ingen robot', 'Verifierar…', 'Verifierad', 'Verifieringen misslyckades', 'Verifieringen misslyckades. Försök igen.'],
+    da:      ['Jeg er ikke en robot', 'Bekræfter…', 'Bekræftet', 'Bekræftelsen mislykkedes', 'Bekræftelsen mislykkedes. Prøv igen.'],
+    nb:      ['Jeg er ikke en robot', 'Bekrefter…', 'Bekreftet', 'Bekreftelsen mislyktes', 'Bekreftelsen mislyktes. Prøv igjen.'],
+    fi:      ['En ole robotti', 'Vahvistetaan…', 'Vahvistettu', 'Vahvistus epäonnistui', 'Vahvistus epäonnistui. Yritä uudelleen.'],
+    cs:      ['Nejsem robot', 'Ověřování…', 'Ověřeno', 'Ověření selhalo', 'Ověření selhalo. Zkuste to znovu.'],
+    sk:      ['Nie som robot', 'Overovanie…', 'Overené', 'Overenie zlyhalo', 'Overenie zlyhalo. Skúste to znova.'],
+    hu:      ['Nem vagyok robot', 'Ellenőrzés…', 'Ellenőrizve', 'Az ellenőrzés sikertelen', 'Az ellenőrzés sikertelen. Próbálja újra.'],
+    ro:      ['Nu sunt robot', 'Se verifică…', 'Verificat', 'Verificare eșuată', 'Verificare eșuată. Încercați din nou.'],
+    el:      ['Δεν είμαι ρομπότ', 'Επαλήθευση…', 'Επαληθεύτηκε', 'Η επαλήθευση απέτυχε', 'Η επαλήθευση απέτυχε. Δοκιμάστε ξανά.'],
+    bg:      ['Не съм робот', 'Проверка…', 'Проверено', 'Проверката е неуспешна', 'Проверката е неуспешна. Опитайте отново.'],
+    ca:      ['No sóc un robot', "S'està verificant…", 'Verificat', 'La verificació ha fallat', 'La verificació ha fallat. Torneu-ho a provar.'],
+  };
+
+  /**
+   * Escapes text destined for innerHTML.
+   *
+   * The shipped strings are safe by construction, but the `strings` option lets
+   * an integrator supply their own, and those may well come from a CMS or a
+   * locale file. Interpolating that into innerHTML unescaped would make the
+   * widget an XSS vector on the very form it is protecting.
+   */
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  // Positional, to keep the table above readable at a glance.
+  const I18N_KEYS = ['label', 'verifying', 'verified', 'failed', 'retry'];
+
+  // Scripts written right-to-left. The widget is a horizontal row — checkbox,
+  // label, branding — so without this the layout reads backwards for roughly
+  // half a billion people.
+  const RTL_LANGUAGES = new Set(['ar', 'he', 'fa', 'ur', 'ps', 'sd', 'yi']);
+
+  /**
+   * Picks the best available translation for a requested tag.
+   *
+   * Exact match first (`pt-BR`), then the base language (`pt`), then English.
+   * Case-insensitive and tolerant of the underscore form some systems emit,
+   * because this value arrives from whatever the page or browser happened to
+   * set and being strict about it would just mean silently falling back.
+   */
+  function resolveLanguage(requested) {
+    if (!requested || typeof requested !== 'string') return 'en';
+    const tag = requested.trim().toLowerCase().replace(/_/g, '-');
+    if (I18N[tag]) return tag;
+    const base = tag.split('-')[0];
+    if (I18N[base]) return base;
+    return 'en';
+  }
+
+  /**
+   * The language the widget should render in, in descending order of how
+   * deliberate the signal is:
+   *
+   *   1. an explicit `lang` option        — the integrator said so
+   *   2. `data-lang` on the container     — the markup said so
+   *   3. `<html lang>`                    — the page said so
+   *   4. `navigator.language`             — the browser said so
+   *   5. English
+   *
+   * The page outranks the browser on purpose: a German speaker reading an
+   * explicitly Japanese page is better served by a widget that matches the form
+   * around it than one that matches their locale.
+   */
+  function detectLanguage(explicit, container) {
+    const candidates = [
+      explicit,
+      container && container.dataset ? container.dataset.lang : null,
+      typeof document !== 'undefined' && document.documentElement
+        ? document.documentElement.getAttribute('lang')
+        : null,
+      typeof navigator !== 'undefined' ? navigator.language : null,
+    ];
+    // Take the first candidate that actually names a language we ship, rather
+    // than the first non-empty one: a page declaring lang="tlh" should not stop
+    // us consulting the browser.
+    for (const candidate of candidates) {
+      if (!candidate || typeof candidate !== 'string') continue;
+      const tag = candidate.trim().toLowerCase().replace(/_/g, '-');
+      if (I18N[tag]) return tag;
+      const base = tag.split('-')[0];
+      if (I18N[base]) return base;
+    }
+    return 'en';
+  }
+
+  /**
+   * Builds the string table for a language, applying any caller overrides.
+   *
+   * `strings` exists so that an integrator whose language we do not ship is not
+   * blocked on us adding it, and so anyone who dislikes a particular rendering
+   * can change it without forking the widget.
+   */
+  function buildStrings(lang, overrides) {
+    const source = I18N[lang] || I18N.en;
+    const strings = {};
+    I18N_KEYS.forEach((key, i) => { strings[key] = source[i]; });
+    if (overrides && typeof overrides === 'object') {
+      for (const key of I18N_KEYS) {
+        if (typeof overrides[key] === 'string') strings[key] = overrides[key];
+      }
+    }
+    return strings;
+  }
 
   // ============================================================
   // Behavioral Signal Collector
@@ -2576,11 +2739,20 @@
         siteKey: null,
         theme: 'light',
         size: 'normal',
+        // null means detect: data-lang, then <html lang>, then navigator.
+        lang: null,
+        // Per-key overrides, for a language we do not ship or a wording an
+        // integrator would rather phrase differently.
+        strings: null,
         callback: null,
         errorCallback: null,
         expiredCallback: null,
         powDifficulty: 4
       }, options);
+
+      this.lang = detectLanguage(this.options.lang || FCaptcha.lang, this.container);
+      this.strings = buildStrings(this.lang, this.options.strings);
+      this.rtl = RTL_LANGUAGES.has(this.lang.split('-')[0]);
 
       this.id = 'fcaptcha_' + Math.random().toString(36).substr(2, 9);
       this.behavioral = new BehavioralCollector();
@@ -2613,8 +2785,11 @@
       const isDark = this.options.theme === 'dark';
 
       this.container.innerHTML = `
-        <div class="fcaptcha-widget ${isDark ? 'fcaptcha-dark' : ''}" id="${this.id}">
+        <div class="fcaptcha-widget ${isDark ? 'fcaptcha-dark' : ''}" id="${this.id}"
+             lang="${this.lang}"${this.rtl ? ' dir="rtl"' : ''}>
           <style>
+            .fcaptcha-widget[dir="rtl"] { flex-direction: row-reverse; }
+            .fcaptcha-widget[dir="rtl"] .fcaptcha-branding { align-items: flex-start; }
             .fcaptcha-widget {
               font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, sans-serif;
               background: ${isDark ? '#1e1e1e' : '#fafafa'};
@@ -2665,12 +2840,22 @@
             .fcaptcha-brand { font-size: 11px; font-weight: 600; color: #ff2a6d; letter-spacing: 0.5px; }
             .fcaptcha-logo { font-size: 9px; font-weight: 500; color: ${isDark ? '#808080' : '#999'}; }
           </style>
-          <div class="fcaptcha-checkbox" role="checkbox" aria-checked="false" tabindex="0">
+          <div class="fcaptcha-checkbox" role="checkbox" aria-checked="false" tabindex="0"
+               aria-labelledby="${this.id}-label">
             <div class="fcaptcha-spinner" style="display: none;"></div>
             <span class="fcaptcha-checkmark">✓</span>
             <span class="fcaptcha-x">✕</span>
           </div>
-          <span class="fcaptcha-label">I'm not a robot</span>
+          <!--
+            aria-labelledby, because the label is a sibling rather than a
+            wrapping <label>: without it the control announced as "checkbox, not
+            checked" with no name at all.
+
+            aria-live, because every state this widget has — verifying, verified,
+            failed — is communicated by swapping this text. A sighted user sees
+            the change; without a live region nobody else is told.
+          -->
+          <span class="fcaptcha-label" id="${this.id}-label" aria-live="polite">${escapeHtml(this.strings.label)}</span>
           <div class="fcaptcha-branding">
             <span class="fcaptcha-brand">WebDecoy</span>
             <span class="fcaptcha-logo">FCaptcha</span>
@@ -2726,7 +2911,7 @@
 
       this.checkbox.classList.add('loading');
       this.spinner.style.display = 'block';
-      this.label.textContent = 'Verifying...';
+      this.label.textContent = this.strings.verifying;
 
       try {
         // Step 1: Collect all signals (sync and async in parallel)
@@ -2787,7 +2972,7 @@
         }
       } catch (error) {
         console.error('FCaptcha error:', error);
-        this._showFailure('Verification failed. Please try again.');
+        this._showFailure(this.strings.retry);
       }
     }
 
@@ -2860,7 +3045,7 @@
         success: passed,
         score,
         token: passed ? btoa(JSON.stringify({ timestamp: Date.now(), score, id: this.id })) : null,
-        message: passed ? null : 'Verification failed'
+        message: passed ? null : this.strings.failed
       };
     }
 
@@ -2871,7 +3056,7 @@
       this.checkbox.classList.add('verified');
       this.checkbox.setAttribute('aria-checked', 'true');
       this.spinner.style.display = 'none';
-      this.label.textContent = 'Verified';
+      this.label.textContent = this.strings.verified;
 
       if (this.options.callback) this.options.callback(token);
       this.container.dispatchEvent(new CustomEvent('fcaptcha:verified', { detail: { token } }));
@@ -2881,13 +3066,13 @@
       this.checkbox.classList.remove('loading');
       this.checkbox.classList.add('failed');
       this.spinner.style.display = 'none';
-      this.label.textContent = message || 'Verification failed';
+      this.label.textContent = message || this.strings.failed;
 
       if (this.options.errorCallback) this.options.errorCallback(message);
 
       setTimeout(() => {
         this.checkbox.classList.remove('failed');
-        this.label.textContent = "I'm not a robot";
+        this.label.textContent = this.strings.label;
       }, 3000);
     }
 
@@ -2905,7 +3090,7 @@
       this.checkbox.classList.remove('verified', 'failed', 'loading');
       this.checkbox.setAttribute('aria-checked', 'false');
       this.spinner.style.display = 'none';
-      this.label.textContent = "I'm not a robot";
+      this.label.textContent = this.strings.label;
       // Fetch new challenge in background
       this._fetchChallenge();
     }
@@ -3223,6 +3408,12 @@
 
   FCaptcha.configure = function(options) {
     if (options.serverUrl) this.serverUrl = options.serverUrl;
+    if (options.lang) this.lang = options.lang;
+  };
+
+  /** The languages the widget ships strings for. */
+  FCaptcha.languages = function() {
+    return Object.keys(I18N);
   };
 
   FCaptcha.getSignals = function() {
@@ -3244,10 +3435,12 @@
       const theme = container.dataset.theme || 'light';
       const endpoint = container.dataset.endpoint;
       const callback = container.dataset.callback ? window[container.dataset.callback] : null;
+      // null rather than a default, so detection still runs when unset.
+      const lang = container.dataset.lang || null;
 
       if (endpoint) FCaptcha.serverUrl = endpoint;
 
-      FCaptcha.render(container, { siteKey, theme, callback });
+      FCaptcha.render(container, { siteKey, theme, lang, callback });
     });
   };
 

--- a/server-go/main.go
+++ b/server-go/main.go
@@ -249,7 +249,10 @@ func main() {
 			http.NotFound(w, r)
 			return
 		}
-		w.Header().Set("Content-Type", "application/javascript")
+		// charset is not optional here. A classic script served without one is
+		// decoded using the *document's* encoding, so the widget's translated
+		// strings render as mojibake on any page that is not already UTF-8.
+		w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
 		http.ServeFile(w, r, clientPath)
 	})
 	r.Handle("/demo/*", http.StripPrefix("/demo/", http.FileServer(http.Dir("./static/demo"))))

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -1640,7 +1640,10 @@ app.post('/api/score', async (req, res) => {
     // the token, so a caller comparing the two sees the same value.
     action: sanitizeAction(action),
     cdata: sanitizeCdata(cdata),
-    recommendation: result.recommendation
+    recommendation: result.recommendation,
+    // Parity with /api/verify and with the Go server: a caller denied a token
+    // needs to know which precondition failed.
+    ...(result.reason ? { reason: result.reason } : {})
   });
 });
 

--- a/server-python/server.py
+++ b/server-python/server.py
@@ -148,7 +148,12 @@ CLIENT_PATH = os.getenv(
 if os.getenv("FCAPTCHA_SERVE_CLIENT", "true").lower() != "false":
     @app.get("/fcaptcha.js")
     async def fcaptcha_js():
-        return FileResponse(CLIENT_PATH, media_type="application/javascript")
+        # charset is not optional here. A classic script served without one is
+        # decoded using the *document's* encoding, so the widget's translated
+        # strings render as mojibake on any page that is not already UTF-8.
+        return FileResponse(
+            CLIENT_PATH, media_type="application/javascript; charset=utf-8"
+        )
 
 
 # =============================================================================
@@ -1745,7 +1750,10 @@ async def score(req: ScoreRequest, request: Request):
         # into the token, so a caller comparing the two sees the same value.
         "action": sanitize_action(req.action),
         "cdata": sanitize_cdata(req.cdata),
-        "recommendation": result["recommendation"]
+        "recommendation": result["recommendation"],
+        # Parity with /api/verify and with the Go server: a caller denied a
+        # token needs to know which precondition failed.
+        **({"reason": result["reason"]} if result.get("reason") else {}),
     }
 
 

--- a/test/browser/tests/i18n.spec.ts
+++ b/test/browser/tests/i18n.spec.ts
@@ -1,0 +1,179 @@
+import { test, expect, Page } from '@playwright/test';
+
+test.setTimeout(60_000);
+
+/**
+ * Renders the widget in a real browser and reads back what a user would see.
+ *
+ * The point of doing this in a browser rather than unit-testing the resolver is
+ * that most of what can go wrong here is DOM-shaped: whether `<html lang>` is
+ * actually consulted, whether `dir="rtl"` reaches the element, whether the
+ * accessible name resolves. None of that is observable from the string table.
+ *
+ * Served through a route interception at a real http://localhost path rather
+ * than page.setContent(), for the reason pow.spec.ts documents: about:blank has
+ * no crypto.subtle, which the widget's SHA-256 helper needs.
+ */
+async function renderWidget(
+  page: Page,
+  opts: { htmlLang?: string; dataLang?: string; renderOptions?: string } = {}
+) {
+  const htmlLang = opts.htmlLang ? ` lang="${opts.htmlLang}"` : '';
+  const dataLang = opts.dataLang ? ` data-lang="${opts.dataLang}"` : '';
+  const renderOptions = opts.renderOptions ?? '{ siteKey: "test" }';
+
+  await page.route('http://localhost:3000/__fcaptcha_i18n__', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+      body: `<!doctype html><html${htmlLang}><head><title>i18n</title></head>
+        <body>
+          <div id="captcha"${dataLang}></div>
+          <script src="http://localhost:3000/fcaptcha.js"></script>
+          <script>
+            window.__ready = false;
+            FCaptcha.configure({ serverUrl: 'http://localhost:3000' });
+            FCaptcha.render('captcha', ${renderOptions});
+            window.__ready = true;
+          </script>
+        </body></html>`,
+    });
+  });
+
+  await page.goto('http://localhost:3000/__fcaptcha_i18n__');
+  await page.waitForFunction(() => (window as any).__ready === true);
+  await page.waitForSelector('.fcaptcha-label');
+}
+
+const label = (page: Page) => page.locator('.fcaptcha-label').innerText();
+const widget = (page: Page) => page.locator('.fcaptcha-widget');
+
+test('an explicit lang option wins over everything else', async ({ page }) => {
+  await renderWidget(page, {
+    htmlLang: 'de',
+    dataLang: 'es',
+    renderOptions: '{ siteKey: "test", lang: "fr" }',
+  });
+  expect(await label(page)).toBe('Je ne suis pas un robot');
+});
+
+test('data-lang is used when no option is given', async ({ page }) => {
+  await renderWidget(page, { htmlLang: 'de', dataLang: 'ja' });
+  expect(await label(page)).toBe('私はロボットではありません');
+});
+
+test('<html lang> is used when nothing more specific is set', async ({ page }) => {
+  // The page outranks the browser deliberately: a widget should match the form
+  // around it rather than the reader's locale.
+  await renderWidget(page, { htmlLang: 'pl' });
+  expect(await label(page)).toBe('Nie jestem robotem');
+});
+
+test('a region tag falls back to its base language', async ({ page }) => {
+  await renderWidget(page, { htmlLang: 'de-AT' });
+  expect(await label(page)).toBe('Ich bin kein Roboter');
+});
+
+test('a region tag with its own entry is preferred over the base', async ({ page }) => {
+  await renderWidget(page, { htmlLang: 'pt-BR' });
+  expect(await label(page)).toBe('Não sou um robô');
+  // pt-BR and pt share the resting label but differ elsewhere; assert the tag
+  // actually resolved rather than that the shared string happens to match.
+  await expect(widget(page)).toHaveAttribute('lang', 'pt-br');
+});
+
+test('an unknown language falls back to English rather than rendering empty', async ({ page }) => {
+  await renderWidget(page, { htmlLang: 'tlh' });
+  expect(await label(page)).toBe("I'm not a robot");
+});
+
+test('the strings option overrides individual keys', async ({ page }) => {
+  await renderWidget(page, {
+    renderOptions: '{ siteKey: "test", lang: "en", strings: { label: "Prove you are human" } }',
+  });
+  expect(await label(page)).toBe('Prove you are human');
+});
+
+test('the strings option can supply a language we do not ship', async ({ page }) => {
+  await renderWidget(page, {
+    renderOptions: '{ siteKey: "test", lang: "is", strings: { label: "Ég er ekki vélmenni" } }',
+  });
+  expect(await label(page)).toBe('Ég er ekki vélmenni');
+});
+
+test('caller-supplied strings are escaped, not injected', async ({ page }) => {
+  // strings may come from a CMS or locale file; interpolating it raw would make
+  // the widget an XSS vector on the form it protects.
+  await renderWidget(page, {
+    renderOptions:
+      '{ siteKey: "test", lang: "en", strings: { label: "<img src=x onerror=window.__xss=1>" } }',
+  });
+  expect(await page.evaluate(() => (window as any).__xss)).toBeUndefined();
+  expect(await page.locator('.fcaptcha-label img').count()).toBe(0);
+  expect(await label(page)).toContain('<img');
+});
+
+test('RTL languages set dir on the widget root', async ({ page }) => {
+  await renderWidget(page, { htmlLang: 'ar' });
+  expect(await label(page)).toBe('لست روبوتًا');
+  await expect(widget(page)).toHaveAttribute('dir', 'rtl');
+  // The row has to flip too, or the checkbox sits on the wrong side.
+  const direction = await widget(page).evaluate(
+    (el) => getComputedStyle(el).flexDirection
+  );
+  expect(direction).toBe('row-reverse');
+});
+
+test('LTR languages do not set dir', async ({ page }) => {
+  await renderWidget(page, { htmlLang: 'fr' });
+  expect(await widget(page).getAttribute('dir')).toBeNull();
+});
+
+test('the widget root carries its resolved lang, for pronunciation', async ({ page }) => {
+  await renderWidget(page, { htmlLang: 'ru' });
+  await expect(widget(page)).toHaveAttribute('lang', 'ru');
+});
+
+test('the checkbox has an accessible name', async ({ page }) => {
+  // It previously had none: the label is a sibling span rather than a wrapping
+  // <label>, so the control announced as "checkbox, not checked" with no name.
+  await renderWidget(page, { htmlLang: 'it' });
+  const checkbox = page.getByRole('checkbox');
+  await expect(checkbox).toHaveAccessibleName('Non sono un robot');
+});
+
+test('the label is a live region so state changes are announced', async ({ page }) => {
+  await renderWidget(page);
+  await expect(page.locator('.fcaptcha-label')).toHaveAttribute('aria-live', 'polite');
+});
+
+test('the widget is served declaring UTF-8', async ({ page }) => {
+  // Without a charset a classic script is decoded using the *document's*
+  // encoding, so every non-ASCII translation renders as mojibake on any page
+  // that is not already UTF-8. Node got this right via Express; Go and Python
+  // both served a bare application/javascript until the translations made it
+  // matter.
+  const res = await page.request.get('http://localhost:3000/fcaptcha.js');
+  expect((res.headers()['content-type'] || '').toLowerCase()).toContain('charset=utf-8');
+});
+
+test('every shipped language renders a non-empty label', async ({ page }) => {
+  await renderWidget(page);
+  const langs: string[] = await page.evaluate(() => (window as any).FCaptcha.languages());
+  expect(langs.length).toBeGreaterThan(30);
+
+  const empties = await page.evaluate((all: string[]) => {
+    const bad: string[] = [];
+    for (const lang of all) {
+      const el = document.createElement('div');
+      document.body.appendChild(el);
+      (window as any).FCaptcha.render(el, { siteKey: 'test', lang });
+      const text = (el.querySelector('.fcaptcha-label') as HTMLElement | null)?.innerText ?? '';
+      if (!text.trim()) bad.push(lang);
+      el.remove();
+    }
+    return bad;
+  }, langs);
+
+  expect(empties).toEqual([]);
+});

--- a/test/browser/tests/pow.spec.ts
+++ b/test/browser/tests/pow.spec.ts
@@ -80,16 +80,28 @@ async function loadWidgetPage(page: Page, overrides: { hardwareConcurrency?: num
 }
 
 test.describe('parallel PoW solver', () => {
-  test('produces a valid token via FCaptcha.execute', async ({ page }) => {
+  test('produces a solution the server accepts', async ({ page }) => {
     await loadWidgetPage(page);
 
     const result = await page.evaluate(async () => {
       const r = await (window as any).FCaptcha.execute('test-site-key', { action: 'login' });
-      return { token: r?.token, score: r?.score, success: r?.success };
+      return { token: r?.token, score: r?.score, success: r?.success, reason: r?.reason };
     });
 
-    expect(result.token, 'execute() did not return a token').toBeTruthy();
-    expect(typeof result.score).toBe('number');
+    // What this test is for is the solver, so that is what it asserts.
+    //
+    // It used to assert a token came back, which quietly asked the captcha to
+    // fail at its job: this is a Playwright-driven Chromium, so
+    // navigator.webdriver is true, and that detection is Dispositive — the score
+    // floors at 0.9 and the token is correctly withheld. The assertion passed
+    // only until the floor shipped, and nothing noticed because these tests run
+    // nowhere in CI.
+    //
+    // A withheld token therefore proves nothing either way. What does is that
+    // the server never rejected the proof of work: the solution the parallel
+    // solver produced verified against the challenge it was issued.
+    expect(result.reason, 'server rejected the solver output').not.toBe('pow_not_satisfied');
+    expect(typeof result.score, 'no score returned — the request did not complete').toBe('number');
   });
 
   test('spawns multiple workers under default hardwareConcurrency', async ({ page }) => {


### PR DESCRIPTION
The widget's entire user-facing vocabulary was five hardcoded English strings. They are now a bundled table of 34 languages, resolved automatically.

## Language resolution

First candidate that names a shipped language wins: explicit `lang` option → `data-lang` on the container → the page's `<html lang>` → `navigator.language` → English. The page outranks the browser deliberately — a widget should match the form around it rather than the reader's locale. Region tags fall back to their base (`de-AT` → `de`); `pt-BR` and `zh-TW` have their own entries where the wording differs.

Bundled rather than fetched: this is a security control on someone else's login form, so a runtime language-pack request would be another origin to trust, another thing to fail closed on a flaky network, and a delay on the critical path. ~3 KB before compression.

A `strings` option overrides any key, so an unshipped language is not a blocker. Those are HTML-escaped — they may come from a CMS or locale file.

Arabic, Hebrew and Persian set `dir="rtl"` and flip the row.

## Accessibility, fixed in passing

Both defects were on the exact lines being translated:

- **The control had no accessible name.** `role="checkbox"` sat beside an unassociated sibling span, so screen readers announced "checkbox, not checked" and nothing more. Now wired with `aria-labelledby`.
- **No state change was announced.** Verifying / verified / failed are all conveyed by swapping that label's text. Now `aria-live="polite"`.

The widget root also carries its resolved `lang`, so the label is pronounced correctly rather than as English.

## A charset bug the translations depend on

A classic script served without a charset is decoded using the *document's* encoding, so every non-ASCII string renders as mojibake on any page that is not already UTF-8. Node was correct via Express; **Go and Python both served a bare `application/javascript`**. Caught by a test fixture, which is the only reason it did not ship.

## A browser test that was asserting the wrong thing

`pow.spec.ts` expected a Playwright-driven Chromium to receive a token — which asks the captcha to fail at its job, since `navigator.webdriver` is `Dispositive` and correctly floors the score at 0.9. It passed only until that floor shipped in v1.18.0, and nothing noticed because **`test/browser` runs nowhere in CI**. It now asserts what its describe block is about — that the parallel solver's output was accepted — and the browser suite runs in CI.

`/api/score` also gained the `reason` field Go's `/api/verify` already reported, so all three servers explain a withheld token identically.

## Tests

16 browser tests: resolution order, region fallback, unknown-tag fallback, overrides, escaping, RTL layout, accessible name, live region, charset, and that every shipped language renders something. Green against all three servers.

Bench unchanged — human FPR 0.00%, TPR 97.33%, gate exits 0. Canvas fingerprint strings verified byte-identical.