### PR TITLE
Add the missing OSS hygiene files and a Helm chart, and fix HEAD requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,45 @@
+name: Bug report
+description: Something does not work as documented.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For a security problem, do not open an issue — see
+        [SECURITY.md](https://github.com/WebDecoy/FCaptcha/blob/main/SECURITY.md).
+
+        For a legitimate visitor being flagged, use the false-positive template
+        instead; it asks for the things that make those diagnosable.
+  - type: textarea
+    id: what
+    attributes:
+      label: What happened
+      description: What you expected, and what happened instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: A `curl` command or a short script beats prose.
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: FCaptcha version
+    validations:
+      required: true
+  - type: checkboxes
+    id: servers
+    attributes:
+      label: Which servers did you check?
+      description: >
+        Go, Python and Node are separate codebases kept in sync by hand, so a bug
+        in one is often — but not always — in the other two. Checking more than
+        one is genuinely useful.
+      options:
+        - label: Go
+        - label: Node
+        - label: Python

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/WebDecoy/FCaptcha/security/advisories/new
+    about: Report privately. Please do not open a public issue for a security problem.
+  - name: Question or idea
+    url: https://github.com/WebDecoy/FCaptcha/discussions
+    about: For anything that is not a bug report or a concrete request.

--- a/.github/ISSUE_TEMPLATE/false-positive.yml
+++ b/.github/ISSUE_TEMPLATE/false-positive.yml
@@ -1,0 +1,48 @@
+name: False positive — a real person was flagged
+description: A legitimate visitor scored as a bot.
+labels: ["false-positive"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        These are the most valuable reports this project gets. Every threshold in
+        the behavioural layer is measured against a panel of human personas
+        (keyboard-only, screen-reader, touch, tremor, elderly, high-latency), and
+        a false positive usually means the panel is missing someone.
+
+        If you can, please also consider contributing the trace itself — see
+        [bench/README.md](https://github.com/WebDecoy/FCaptcha/blob/main/bench/README.md).
+  - type: textarea
+    id: score
+    attributes:
+      label: The verdict
+      description: >
+        The score and the detections. Set `FCAPTCHA_LOG_VERDICTS=1` on the server
+        and paste the JSON line. Do not include `FCAPTCHA_LOG_VERDICTS_INCLUDE_RAW`
+        output if it might contain visitor data.
+      render: json
+    validations:
+      required: true
+  - type: textarea
+    id: visitor
+    attributes:
+      label: Who was flagged
+      description: >
+        Browser and version, OS, device. Anything about how they interact that
+        might be relevant — assistive technology, an input device other than a
+        mouse, a slow or high-latency connection, privacy extensions.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: FCaptcha version
+    validations:
+      required: true
+  - type: dropdown
+    id: server
+    attributes:
+      label: Which server
+      options: [Go, Node, Python, "Docker image", "Managed (fcaptcha.webdecoy.com)"]
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## What and why
+
+<!-- What changes, and the reasoning. Long is fine — this codebase documents why. -->
+
+## Checklist
+
+- [ ] Detection changes are applied to **all three** servers (Go, Python, Node), or
+      this does not touch detection
+- [ ] Server unit tests pass (`go test -race`, `npm test`, `unittest discover`)
+- [ ] `node test/test-detection.js` passes against a running server
+- [ ] `cd bench && node run-bench.js --gate` passes — no signal over its
+      false-positive budget
+- [ ] New thresholds are **measured** on the bench, not guessed or borrowed
+- [ ] No persona in the human panel scores higher than before (keyboard-only,
+      screen-reader, touch, tremor, elderly, high-latency)
+
+## If this adds a detector
+
+Which is it? See [CONTRIBUTING.md](../CONTRIBUTING.md#adding-a-detector) — the
+weighted sum means an under-weighted category can be certain and still never
+change a verdict.
+
+- [ ] **Evidence** — correlates with automation, scored with an honest confidence
+- [ ] **Precondition** — the mechanism was skipped; gated outside the score
+- [ ] **Dispositive** — a browser cannot produce this without being automated
+
+## Breaking changes
+
+<!-- Anything an existing integrator must do. Write "none" if none. -->

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,118 @@
+name: Helm chart
+
+# The chart is a deployment path like any other, so it gets the same treatment:
+# it is linted, rendered across the combinations people actually use, validated
+# against real Kubernetes schemas, and then installed into a throwaway cluster
+# and asked to prove it serves traffic.
+#
+# Rendering is not enough on its own. Writing this chart turned up two things
+# that only a real install surfaces: HEAD returned 405 on two of the three
+# servers, and a failed `helm test` pod was never cleaned up, so every
+# subsequent run re-reported the first failure.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'charts/**'
+      - '.github/workflows/helm.yml'
+  pull_request:
+    paths:
+      - 'charts/**'
+      - 'docker/**'
+      - 'server-go/**'
+      - 'client/**'
+      - '.github/workflows/helm.yml'
+
+jobs:
+  lint-and-render:
+    name: Lint, render, validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.3
+
+      - name: Lint
+        run: helm lint charts/fcaptcha --set secret=ci
+
+      # The guard is the chart's only defence against a deployment signing tokens
+      # with a key published in the source, so it is worth a test of its own.
+      - name: Refuses to render without a signing key
+        run: |
+          if helm template t charts/fcaptcha >/dev/null 2>&1; then
+            echo "chart rendered without a secret — the guard is broken"
+            exit 1
+          fi
+          echo "guard holds"
+
+      - name: Install kubeconform
+        run: |
+          curl -sSL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz \
+            | tar xz -C /usr/local/bin kubeconform
+
+      - name: Render and validate every combination
+        run: |
+          set -e
+          render() {
+            name="$1"; shift
+            helm template t charts/fcaptcha "$@" > "/tmp/$name.yaml"
+            kubeconform -strict -summary -kubernetes-version 1.30.0 "/tmp/$name.yaml"
+          }
+          render minimal        --set secret=ci
+          render existing       --set existingSecret=mine
+          render ingress        --set secret=ci --set ingress.enabled=true
+          render scaling        --set secret=ci --set autoscaling.enabled=true --set podDisruptionBudget.enabled=true
+          render redis          --set secret=ci --set redis.url=redis://r:6379
+          render full           --set secret=ci --set ingress.enabled=true --set autoscaling.enabled=true \
+                                --set podDisruptionBudget.enabled=true --set config.logVerdicts=true \
+                                --set config.allowedHostnames=a.example --set verifySecret=v
+
+  install:
+    name: Install into a cluster
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.16.3
+
+      - uses: helm/kind-action@v1
+        with:
+          cluster_name: fcaptcha-chart
+
+      # Built from this commit rather than pulled from GHCR: the point is to test
+      # the chart against the code in the PR, not against the last release.
+      - name: Build the image
+        run: docker build -f docker/Dockerfile -t fcaptcha:ci .
+
+      - name: Load it into the cluster
+        run: kind load docker-image fcaptcha:ci --name fcaptcha-chart
+
+      - name: Install
+        run: |
+          helm install fc charts/fcaptcha \
+            --namespace fcaptcha --create-namespace \
+            --set secret=$(openssl rand -hex 32) \
+            --set image.repository=fcaptcha \
+            --set image.tag=ci \
+            --set image.pullPolicy=Never \
+            --wait --timeout 5m
+
+      - name: Test
+        run: helm test fc -n fcaptcha --logs
+
+      # A failed hook pod used to block every later run by colliding with its own
+      # name; running twice is what catches that regressing.
+      - name: Test again, to prove it is re-runnable
+        run: helm test fc -n fcaptcha
+
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          kubectl -n fcaptcha get pods -o wide || true
+          kubectl -n fcaptcha describe pods || true
+          kubectl -n fcaptcha logs -l app.kubernetes.io/name=fcaptcha --tail=100 || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,195 @@
+# Changelog
+
+Notable changes per release. Full notes, including the reasoning behind each
+change, are on the [releases page](https://github.com/WebDecoy/FCaptcha/releases).
+
+This file exists because FCaptcha is a security dependency: anyone deciding
+whether to take an upgrade should be able to see what moved without reading a
+diff. **Breaking changes and anything security-relevant are called out
+explicitly.**
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
+the project uses [Semantic Versioning](https://semver.org/) — with the caveat
+that pre-2.0 it has used minor bumps for behaviour changes that a stricter
+reading would call major. Read the **Breaking** entries rather than the number.
+
+## [1.25.0] — 2026-08-20
+
+### Added
+- `@webdecoy/fcaptcha-client` — the browser widget as its own npm package, so a
+  CDN URL exists and trying FCaptcha no longer requires standing up a server.
+- Minified build: 131.8 KB → 67.6 KB, 17.5 KB over the wire with Brotli.
+- Subresource Integrity digests for both widget files, published per release. If
+  you load the widget from a CDN, pin the version and use the hash.
+
+## [1.24.0] — 2026-08-20
+
+### Added
+- The widget is localized into 34 languages, detected from an explicit `lang`
+  option, `data-lang`, the page's `<html lang>`, or the browser. Right-to-left
+  layout for Arabic, Hebrew and Persian. A `strings` option overrides any key.
+
+### Fixed
+- **Accessibility:** the checkbox had no accessible name — `role="checkbox"` sat
+  beside an unassociated label, so screen readers announced "checkbox, not
+  checked" and nothing else. State changes (verifying / verified / failed) were
+  also never announced. Both fixed.
+- The Go and Python servers served the widget without a charset, so non-ASCII
+  strings would render as mojibake on any page not already UTF-8.
+- `/api/score` now reports the `reason` a token was withheld, matching
+  `/api/verify`.
+
+## [1.23.0] — 2026-08-19
+
+### Security
+- **A valid proof of work is now required for a token.** It was previously
+  scored as evidence rather than enforced, and because the final score is a
+  weighted sum in which any category contributes at most its own weight (`bot`
+  is 0.13, against a 0.5 threshold), a bare `curl` sending
+  `{"siteKey":"x","signals":{}}` was issued a valid token — on every server,
+  every time. Every detector fired correctly; the aggregation discarded the
+  verdict. Present in 1.21.0 and earlier.
+- Missing, unverifiable and nonce-unbound solutions are now `dispositive`, so
+  the reported score is 0.9 rather than 0.4.
+
+### Fixed
+- The three servers emitted mutually unverifiable tokens (Go padded base64url,
+  Node unpadded, Python a differently-spaced signing payload). Only surfaced in
+  a mixed fleet, where the instance validating a token is not the one that
+  minted it. All three now agree, and accept the old encodings.
+
+### Breaking
+- A custom client calling `/api/verify` directly must complete the handshake.
+  There is no flag to restore the old behaviour — it was a bypass.
+
+## [1.22.0] — 2026-08-19
+
+### Added
+- Turnstile / reCAPTCHA / hCaptcha `siteverify` compatibility on
+  `/turnstile/v0/siteverify`, `/recaptcha/api/siteverify` and `/siteverify`.
+  Migrating an existing backend integration is a base-URL change.
+- Tokens carry a signed `hostname`, `action` and `cdata`, so a backend can reject
+  a token minted on another site or for a different action.
+- `FCAPTCHA_VERIFY_SECRET`, `FCAPTCHA_ALLOWED_HOSTNAMES`, and `idempotency_key`
+  support for safe retries.
+
+### Security
+- **`secret` is now checked on token verification.** All three servers accepted
+  the parameter and ignored it, so anyone who could reach `/api/token/verify`
+  could spend a token — and since tokens are single-use, burn a real visitor's.
+  The README had always documented sending it, which made the omission worse.
+
+### Breaking
+- `/api/token/verify` requires `secret`. `FCAPTCHA_LEGACY_UNAUTH_VERIFY=true`
+  restores the old behaviour for one release.
+
+## [1.21.0] — 2026-07-28
+
+### Added
+- Adaptive challenge cost: escalation moved to wall-clock (`minAgeMs`) rather
+  than proof-of-work difficulty, priced from a per-source suspicion ledger.
+  Datacenter addresses no longer raise difficulty.
+
+## [1.20.0] — 2026-07-28
+
+### Fixed
+- Signal accuracy: `webdriver_configurable` and `chrome_runtime_missing` fire on
+  genuine Chrome. Measured on the bench, then removed.
+
+## [1.19.0] – [1.19.2] — 2026-07-28
+
+### Added
+- Native JA4-TLS fingerprinting from the ClientHello when the Go server
+  terminates TLS itself, rather than trusting a proxy header. Go 1.24.
+- Node and Python container images.
+
+### Fixed
+- The published Docker image returned 404 for `/fcaptcha.js` for three months
+  (`resolveClientPath` did not probe `./static/`). A smoke test now catches it.
+
+## [1.18.0] — 2026-07-28
+
+### Added
+- The measurement harness (`bench/`): a labelled corpus, a replayer, and
+  per-signal false-positive budgets enforced in CI. Every threshold in the
+  behavioural layer was re-derived from it.
+- Input forensics v2: typing cadence, paste/platform contradictions,
+  programmatic fill, scroll morphology, font/OS coherence.
+
+### Fixed
+- **Score aggregation within a category is now noisy-OR, not a confidence-weighted
+  mean.** The mean made corroborating evidence *lower* the verdict: WebDriver
+  alone scored 0.950, and WebDriver plus seven more automation signals scored
+  0.686.
+- Dispositive signals (`navigator.webdriver`, driver-injected globals) set a 0.9
+  floor, because a weighted sum across ~12 categories otherwise caps a blatant
+  local agent near 0.5.
+
+## [1.17.0] — 2026-07-27
+
+### Added
+- Web Bot Auth protocol-00 typed directory discovery.
+- Bounded per-siteKey state: caller-supplied site keys could allocate unbounded
+  server memory.
+
+## [1.16.0] — 2026-07-27
+
+### Security
+- Trusted-proxy client IP resolution. `X-Forwarded-For` and `X-Real-IP` are read
+  only from a peer in `TRUSTED_PROXIES`; previously any client could claim a
+  clean residential address and skip the datacenter, Tor/VPN and rate-limit
+  checks.
+
+### Breaking
+- Deployments behind a reverse proxy must set `TRUSTED_PROXIES` or every visitor
+  is attributed to the proxy.
+
+## [1.15.0] — 2026-07-24
+
+### Added
+- Web Bot Auth (RFC 9421) signature verification against the agent's published
+  key directory, for Go and Node. A signature claiming an identity and failing to
+  prove it is the interesting outcome.
+
+## [1.14.0] — 2026-06-29
+
+### Added
+- Stealth-patch artifact detection for cloud AI agents.
+
+## [1.11.0] – [1.13.0] — 2026-06
+
+### Added
+- Declared AI agent detection (ClaudeBot, GPTBot, PerplexityBot and similar) as
+  its own category, so a deployment can allow polite agents and block the rest.
+- Input-event forensics and think-time cadence.
+
+### Fixed
+- Proof-of-work deadlock and reverse-DNS timeout.
+
+## [1.6.0] – [1.10.2] — 2026-03 → 2026-06
+
+### Added
+- Signal commitment binding the challenge to the collected signals, per-challenge
+  nonces, full 256-bit HMAC signatures.
+- Parallel client-side proof of work; single-origin widget delivery;
+  mobile-native detection.
+
+### Security
+- HMAC signatures are no longer truncated to 64 bits.
+
+## [1.0.0] – [1.5.0] — 2026-02
+
+Initial releases: proof of work, behavioural biometrics, headless and automation
+detection, Docker images and one-command deploys, keystroke cadence analysis.
+
+[1.25.0]: https://github.com/WebDecoy/FCaptcha/releases/tag/v1.25.0
+[1.24.0]: https://github.com/WebDecoy/FCaptcha/releases/tag/v1.24.0
+[1.23.0]: https://github.com/WebDecoy/FCaptcha/releases/tag/v1.23.0
+[1.22.0]: https://github.com/WebDecoy/FCaptcha/releases/tag/v1.22.0
+[1.21.0]: https://github.com/WebDecoy/FCaptcha/releases/tag/v1.21.0
+[1.20.0]: https://github.com/WebDecoy/FCaptcha/releases/tag/v1.20.0
+[1.18.0]: https://github.com/WebDecoy/FCaptcha/releases/tag/v1.18.0
+[1.17.0]: https://github.com/WebDecoy/FCaptcha/releases/tag/v1.17.0
+[1.16.0]: https://github.com/WebDecoy/FCaptcha/releases/tag/v1.16.0
+[1.15.0]: https://github.com/WebDecoy/FCaptcha/releases/tag/v1.15.0
+[1.14.0]: https://github.com/WebDecoy/FCaptcha/releases/tag/v1.14.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Code of Conduct
+
+## The short version
+
+Be decent. Assume good faith. Criticise code and ideas, not people.
+
+## Scope
+
+This applies in the issue tracker, pull requests, discussions, and anywhere else
+someone is representing the project.
+
+## What is expected
+
+- Treat disagreement as normal and resolve it with evidence. This project has a
+  measurement harness precisely so that "I think this fires on real users" can
+  become "here is the run where it does".
+- Accept that a maintainer may decline a change, and that a contributor may
+  decline to make one.
+- Respect that people arrive with different levels of context. A question that
+  seems obvious to you is usually not obvious to the person asking.
+
+## What is not
+
+Harassment, personal attacks, demeaning comments, unwelcome sexual attention,
+publishing others' private information, and sustained disruption.
+
+A note specific to this project: FCaptcha exists partly to keep automated systems
+away from real people, and some contributions concern evasion techniques. Discuss
+them technically. Do not use the project's spaces to organise abuse of anyone
+else's site.
+
+## Reporting
+
+Email **hello@webdecoy.com**. Reports are read by the maintainers and handled
+privately.
+
+Consequences scale with the conduct, from a request to stop, to removal of
+comments, to a ban. There is no appeals bureaucracy here; there is a small
+project trying to be a reasonable place to contribute to.
+
+## Attribution
+
+Adapted in spirit from the [Contributor Covenant](https://www.contributor-covenant.org/),
+shortened deliberately — a document nobody finishes reading protects nobody.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,116 @@
+# Contributing
+
+## The rule that matters most
+
+**A change to detection lands in all three servers.** Go, Python and Node are
+separate implementations of the same algorithm, kept in sync by hand. A detector
+added to one and not the others means the same visitor is scored differently
+depending on which server answered — and because nothing fails when they drift,
+it stays wrong until somebody notices.
+
+The same applies to the wire format. Tokens were mutually unverifiable across the
+three servers for months (Go emitted padded base64url, Node unpadded, Python
+signed a payload with different JSON spacing) because each only ever verified its
+own. Byte-identical fixtures in `server-*/…siteverify` tests now pin that; keep
+them in step.
+
+## What is most useful right now
+
+**Captured traces from real browsers driven by real people.** The benchmark
+corpus is scripted personas from a single machine, which bounds what any
+false-positive number derived from it can mean. `bench/corpus/captured/` takes
+new samples directly — see [bench/README.md](bench/README.md). This is the single
+highest-value contribution to the project, above any feature.
+
+Other open areas:
+
+- Web Bot Auth verification for the Python server. Go and Node verify
+  cryptographically against the agent's published key directory; Python still
+  identifies by header presence, because there is no maintained Python library.
+- Cross-session / per-fingerprint behavioural correlation — the durable defence
+  against source-patched browsers.
+- An escalation path for a flagged visitor. Today a false positive is a dead end
+  with no recourse, which is the largest product gap.
+- `/metrics`, and the score histogram an operator needs to tune their threshold.
+- Redis-backed distributed state (currently in-memory).
+- WebAssembly proof of work for better low-end mobile performance.
+
+## Before you open a pull request
+
+```bash
+# server unit tests
+cd server-go     && go vet ./... && go test -race ./...
+cd server-node   && npm test
+cd server-python && pip install -r requirements.txt && python -m unittest discover -p 'test_*.py'
+
+# end-to-end, against a running server
+cd server-node && npm start &
+node test/test-detection.js
+
+# the widget in a real browser
+cd client && npm install && npm run build      # so the minified comparison has something to compare
+cd test/browser && npm install && npx playwright install chromium && npm test
+
+# the false-positive gate
+cd bench && npm install && node run-bench.js --gate
+```
+
+CI runs all of this. The bench gate is the one that blocks on a number: a signal
+firing on the human panel more often than its budget allows fails the build.
+
+## Adding a detector
+
+Read [the note on scoring](README.md#how-the-score-is-composed) first, because
+the aggregation is not obvious and has bitten before.
+
+The final score is a **weighted sum across ~12 categories, so any one category
+contributes at most its own weight**. `bot` is weighted 0.13 against a 0.5
+threshold. A detector added to an under-weighted category can be completely
+certain and still never change a verdict — which is exactly how the proof of work
+went unenforced until v1.23.0.
+
+So, before writing one, decide which kind of thing you have:
+
+- **Evidence** — correlates with automation, could be wrong. Score it, pick a
+  confidence honestly, and expect it to matter only in combination.
+- **A precondition** — the mechanism was skipped rather than beaten. Gate on it
+  outside the score, the way a missing proof of work or an unlisted hostname is
+  handled. Do not express this as a high score and hope.
+- **Dispositive** — a browser cannot produce this without being automated
+  (`navigator.webdriver`, driver-injected globals). Mark it `Dispositive` and it
+  floors the score. The bar is high on purpose: "the console is attached" does
+  not qualify, because a developer with DevTools open trips it.
+
+Then measure it. Every threshold in the behavioural layer came from the bench
+rather than from intuition or from another project's published numbers, and a new
+one should too. `node run-bench.js` reports the per-signal false-positive rate
+against the human panel; if your detector fires on the screen-reader or
+motor-tremor persona, that is a finding about the detector.
+
+## Accessibility
+
+Non-negotiable, and repeatedly the thing that catches people out. The bench
+carries keyboard-only, screen-reader, touch, tremor, elderly and high-latency
+personas because each of them looks like automation to a naive detector: no mouse
+movement, unnaturally slow input, no micro-tremor, perfectly consistent timing.
+
+Existing exemptions (keyboard-only users with no pointer events, touch users) are
+load-bearing. If a change makes one of those personas score higher, that is a
+false positive on a real user, not a tuning opportunity.
+
+## Style
+
+Match the surrounding code — the servers each read like idiomatic code in their
+own language rather than a transliteration of one another.
+
+Comments explain **why**, not what. The codebase leans heavily on this: most
+non-obvious constants and every unusual decision carry the reasoning and often
+the measurement that produced them. If you find yourself writing a number, write
+down where it came from.
+
+Commit messages follow Conventional Commits (`feat(scope):`, `fix(scope):`,
+`chore(scope):`) with a body that explains the reasoning. Long is fine.
+
+## Reporting a security issue
+
+Do not open a public issue. See [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -55,6 +55,21 @@ With Redis (for distributed state):
 FCAPTCHA_SECRET=my-secret docker compose -f docker/docker-compose.yml up -d
 ```
 
+Kubernetes:
+
+```bash
+helm install fcaptcha ./charts/fcaptcha \
+  --namespace fcaptcha --create-namespace \
+  --set secret=$(openssl rand -hex 32)
+
+helm test fcaptcha -n fcaptcha
+```
+
+The chart refuses to install without a signing key — see
+[charts/fcaptcha](charts/fcaptcha/README.md), which also covers the
+`trustedProxies` setting that matters more behind an ingress controller than
+anywhere else.
+
 Deploy to Fly.io:
 
 ```bash
@@ -945,22 +960,19 @@ reverse proxy.
 
 ## Contributing
 
-Contributions welcome! Please read [ARCHITECTURE.md](ARCHITECTURE.md) first. AI-agent detection is built out in phases — declared agents, input-event forensics, Web Bot Auth signature verification, the measurement harness, and typing/scroll/platform-coherence forensics have shipped; hosted-agent environment composites, accessibility-tree honeypots, and cross-session correlation are still open.
+Contributions welcome — please read [CONTRIBUTING.md](CONTRIBUTING.md) first. AI-agent detection is built out in phases — declared agents, input-event forensics, Web Bot Auth signature verification, the measurement harness, and typing/scroll/platform-coherence forensics have shipped; hosted-agent environment composites, accessibility-tree honeypots, and cross-session correlation are still open.
 
 The most useful contribution right now is **captured traces from real browsers
 driven by real people**. The benchmark corpus is currently scripted personas from
 a single machine, which bounds what any false-positive number from it can mean.
 `bench/corpus/captured/` takes new samples directly — see [bench/README.md](bench/README.md).
 
-Areas that could use help:
-- Web Bot Auth verification for the Python server (Go and Node verify cryptographically against the agent's published key directory; Python still identifies by header presence — no maintained Python library yet)
-- Cross-session / per-fingerprint behavioral correlation (the durable defense against source-patched browsers)
-- Machine learning-based scoring
-- Admin dashboard and analytics
-- WebAssembly-based PoW for better mobile performance
-- Redis-backed distributed state (currently in-memory)
+Other open areas are listed in [CONTRIBUTING.md](CONTRIBUTING.md#what-is-most-useful-right-now),
+along with how to run the test suites and what to measure before adding a detector.
 
 When adding or changing a detector, apply it to **all three** server implementations (Go, Python, Node) so they stay in sync.
+
+Security problems go to [SECURITY.md](SECURITY.md), not the issue tracker.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,107 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security problem.**
+
+Use [GitHub's private vulnerability reporting](https://github.com/WebDecoy/FCaptcha/security/advisories/new),
+which is enabled on this repository. If that is unavailable to you, email
+**hello@webdecoy.com** with `FCaptcha security` in the subject.
+
+What helps most, roughly in order:
+
+- What the issue lets an attacker do, stated plainly.
+- A reproduction. A `curl` command or a short script beats prose.
+- Which server implementations you checked. Go, Python and Node are separate
+  codebases kept in sync by hand, so a finding in one is often — but not
+  always — present in the other two.
+- The version or commit.
+
+You do not need a working exploit, and you do not need to be sure. A clear
+description of something that looks wrong is worth sending.
+
+### What to expect
+
+- **Acknowledgement within 3 working days.** If you have not heard back, assume
+  the mail went astray and ping the issue tracker without details.
+- An assessment, including whether we agree it is a vulnerability and why.
+- A fix in a release, with credit in the release notes unless you would rather
+  not be named.
+
+This is a small project without a paid security team; there is no bug bounty.
+What there is, is a genuine interest in being told.
+
+## Scope
+
+In scope: anything in this repository — the three servers, the browser widget,
+the benchmark harness, and the published `@webdecoy/fcaptcha` and
+`@webdecoy/fcaptcha-client` packages and container images.
+
+Particularly interesting:
+
+- **Token forgery or replay** — minting a token without completing a challenge,
+  or spending one twice.
+- **Verification bypass** — anything that gets a passing verdict without doing
+  the work. See the note below on scoring.
+- **Signal spoofing that is cheap and general** — a technique that makes any
+  automated browser score like a human, as distinct from a hand-tuned evasion of
+  one detector.
+- **Anything that harms legitimate visitors** — a false positive that can be
+  induced remotely, a way to get another user blocked, or a denial of service
+  against the scoring path.
+
+## A note on what counts as a vulnerability here
+
+This is a detection system, so "I evaded a detector" and "I broke the security
+model" are different claims, and it is worth being explicit about which is which.
+
+**Individual detector evasion is expected.** Every behavioural and environmental
+signal can be defeated by someone willing to spend enough effort — that is the
+nature of the problem, and the scoring is designed around accumulating evidence
+rather than relying on any single tell. A patched Chromium that hides
+`navigator.webdriver` is not a vulnerability report; it is the adversary the
+roadmap already assumes. Please do send it if the technique is cheap, general,
+and defeats many signals at once.
+
+**Structural bypasses are vulnerabilities.** Anything that skips the mechanism
+rather than beating it: forging a token, replaying a challenge, getting a token
+without a valid proof of work, making the server trust a header it should not.
+
+A worked example of the second kind, fixed in v1.23.0: the proof of work was
+scored as evidence rather than enforced as a precondition, and because the final
+score is a weighted sum in which any one category contributes at most its own
+weight, a bare `curl` sending `{"siteKey":"x","signals":{}}` was issued a valid
+token. Every detector fired correctly; the aggregation discarded the verdict.
+That is the shape of a report worth sending.
+
+## Supported versions
+
+The latest minor release receives security fixes. Given how young this project
+is, older lines are not maintained — upgrade rather than expect a backport.
+
+| Version | Supported |
+|---------|-----------|
+| 1.25.x  | Yes       |
+| < 1.25  | No        |
+
+## Deployment notes that are security-relevant
+
+Several ways to make a correct build insecure, documented because they are easy
+to get wrong and fail quietly:
+
+- **`FCAPTCHA_SECRET`** signs every token. Set it. The default,
+  `dev-secret-change-in-production`, is in the source and therefore public — a
+  deployment using it can have tokens minted by anyone.
+- **`TRUSTED_PROXIES`** decides whose `X-Forwarded-For` is believed. Left
+  unset behind a proxy, every visitor is attributed to the proxy and rate
+  limiting collapses onto one address. Set wrong, a client can claim any IP.
+  See [Trusted proxies](README.md#trusted-proxies).
+- **`FCAPTCHA_LEGACY_UNAUTH_VERIFY`** disables the secret check on token
+  verification. It exists only as one release of migration cover and should not
+  be on.
+- **Check `hostname` and `action`** from the verification response. They are
+  signed into the token so that a token minted on another site, or for another
+  action, can be rejected — but only if you look.
+- **Pin and integrity-check the widget** if you load it from a CDN. A captcha is
+  the control deciding whether a request is trusted; a CDN that can silently
+  replace it can switch it off. Digests are published with each release.

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,3 +1,9 @@
+# Identifies this repository to Artifact Hub, which indexes charts/ and renders
+# each chart's README on its listing page.
+#
+# This file existed for months pointing at nothing: the repositoryID was
+# registered while charts/ did not exist, so the listing had no chart to publish.
+# charts/fcaptcha is that chart.
 repositoryID: fcaptcha
 owners:
   - name: WebDecoy

--- a/charts/fcaptcha/.helmignore
+++ b/charts/fcaptcha/.helmignore
@@ -1,0 +1,3 @@
+.DS_Store
+.git/
+*.tgz

--- a/charts/fcaptcha/Chart.yaml
+++ b/charts/fcaptcha/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: fcaptcha
+description: Open source CAPTCHA with proof of work, behavioural biometrics, and AI-agent detection
+type: application
+# Chart version moves independently of the app: a fix to a template is a chart
+# release, not an FCaptcha release.
+version: 0.1.0
+appVersion: "1.25.0"
+home: https://github.com/WebDecoy/FCaptcha
+sources:
+  - https://github.com/WebDecoy/FCaptcha
+maintainers:
+  - name: WebDecoy
+    email: hello@webdecoy.com
+keywords:
+  - captcha
+  - bot-detection
+  - proof-of-work
+  - security
+  - anti-bot
+annotations:
+  artifacthub.io/license: MIT
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://github.com/WebDecoy/FCaptcha#readme
+    - name: Security policy
+      url: https://github.com/WebDecoy/FCaptcha/blob/main/SECURITY.md

--- a/charts/fcaptcha/README.md
+++ b/charts/fcaptcha/README.md
@@ -1,0 +1,86 @@
+# FCaptcha Helm chart
+
+Open source CAPTCHA with proof of work, behavioural biometrics, and AI-agent
+detection. Self-hosted, no external dependencies.
+
+```bash
+helm install fcaptcha oci://ghcr.io/webdecoy/charts/fcaptcha \
+  --namespace fcaptcha --create-namespace \
+  --set secret=$(openssl rand -hex 32)
+```
+
+Or from a checkout:
+
+```bash
+helm install fcaptcha ./charts/fcaptcha \
+  --namespace fcaptcha --create-namespace \
+  --set secret=$(openssl rand -hex 32)
+
+helm test fcaptcha -n fcaptcha
+```
+
+## The chart will not install without a signing key
+
+Deliberately. The server falls back to `dev-secret-change-in-production`, which
+is published in its own source, so a deployment that forgets to set one does not
+fail — it quietly accepts tokens that anyone can mint. A template error is the
+only way to make that impossible to do by accident.
+
+Set `secret`, or point `existingSecret` at a Secret you manage with
+sealed-secrets, External Secrets or SOPS.
+
+## Read this before production
+
+**`config.trustedProxies` decides whose `X-Forwarded-For` is believed**, and it
+matters more in Kubernetes than anywhere else: traffic arrives through an ingress
+controller, which is a proxy. If it is not trusted, every visitor is attributed
+to the controller and rate limiting collapses onto one address — silently. The
+default covers the usual in-cluster pod CIDRs; narrow it to your controller's
+range.
+
+**Run one replica for now.** Server state — issued tokens, PoW challenges, rate
+limits — is in-memory and not shared, so a token minted by one pod is unknown to
+another. Single-use enforcement and rate limiting are therefore per-pod.
+`autoscaling` is off by default for the same reason, and the chart warns if you
+raise `replicaCount`. Redis-backed state is on the roadmap; `redis.url` is
+plumbed through in anticipation but the servers do not use it yet.
+
+The full list of deployment settings with security consequences is in
+[SECURITY.md](https://github.com/WebDecoy/FCaptcha/blob/main/SECURITY.md#deployment-notes-that-are-security-relevant).
+
+## Values
+
+| Key | Description | Default |
+|---|---|---|
+| `secret` | Token signing key. **Required** unless `existingSecret` is set | `""` |
+| `existingSecret` | Name of a Secret you manage, instead of one the chart creates | `""` |
+| `existingSecretKey` | Key within that Secret | `FCAPTCHA_SECRET` |
+| `verifySecret` | Credential a backend presents when verifying a token. Empty means "same as the signing key". Splitting them means a leaked verify credential cannot also mint tokens | `""` |
+| `config.trustedProxies` | Peers allowed to set `X-Forwarded-For` / `X-Real-IP` / TLS-fingerprint headers | in-cluster private ranges |
+| `config.allowedHostnames` | Comma-separated hostnames permitted to mint tokens. Empty accepts any origin | `""` |
+| `config.siteKeys` | Comma-separated allowlist of accepted site keys | `""` |
+| `config.logVerdicts` | One privacy-safe JSON line per verification | `false` |
+| `config.logVerdictsIncludeRaw` | Also log free-text detection reasons. **Can contain visitor-derived data** | `false` |
+| `image.repository` / `image.tag` | Container image; tag defaults to the chart's `appVersion` | `ghcr.io/webdecoy/fcaptcha` |
+| `replicaCount` | See the note above before raising this | `1` |
+| `redis.url` / `redis.existingSecret` | Plumbed through; not yet used by the servers | `""` |
+| `service.type` / `service.port` | | `ClusterIP` / `80` |
+| `ingress.enabled` | | `false` |
+| `resources` | | 100m CPU / 128Mi requested |
+| `autoscaling.enabled` | Off by default — replicas do not share state | `false` |
+| `podDisruptionBudget.enabled` | | `false` |
+| `extraEnv` | Anything the chart does not model | `[]` |
+
+Security defaults are on and not parameterised down: non-root (uid 65532),
+read-only root filesystem, all capabilities dropped, `RuntimeDefault` seccomp, no
+service-account token mounted. The image is a single static binary that writes
+nothing but `/tmp`.
+
+## What `helm test` checks
+
+More than liveness. `/health` only proves the process is up, and the published
+image once returned 404 for `/fcaptcha.js` for three months while health stayed
+green. The test checks that the widget is served, that it declares UTF-8 (the
+translations are decoded using the document's encoding otherwise), that the
+Turnstile-compatible `siteverify` endpoint answers, and that a request carrying
+no proof of work is refused a token.

--- a/charts/fcaptcha/templates/NOTES.txt
+++ b/charts/fcaptcha/templates/NOTES.txt
@@ -1,0 +1,35 @@
+{{ .Chart.Name }} {{ .Chart.AppVersion }} is installed as {{ include "fcaptcha.fullname" . }}.
+
+Reach it:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+{{- else }}
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "fcaptcha.fullname" . }} 8080:{{ .Values.service.port }}
+  curl http://localhost:8080/health
+{{- end }}
+
+Point the widget at it:
+
+  <script src="http://<your-host>/fcaptcha.js"></script>
+  <script>FCaptcha.configure({ serverUrl: 'http://<your-host>' });</script>
+
+{{ if not .Values.config.trustedProxies -}}
+WARNING: trustedProxies is empty. Traffic reaching this service through an
+ingress controller arrives from the controller's address, and with no proxy
+trusted every visitor is attributed to it — rate limiting and IP reputation
+collapse onto a single address, silently. Set config.trustedProxies to your
+ingress controller's pod CIDR.
+
+{{ end -}}
+{{- if gt (int .Values.replicaCount) 1 -}}
+WARNING: replicaCount is {{ .Values.replicaCount }}, but server state (issued
+tokens, PoW challenges, rate limits) is in-memory and not shared. A token minted
+by one pod is unknown to the others, so single-use enforcement and rate limiting
+are per-pod. Run one replica until Redis-backed state lands, or accept it
+knowingly.
+
+{{ end -}}
+Before production, read:
+  https://github.com/WebDecoy/FCaptcha/blob/main/SECURITY.md#deployment-notes-that-are-security-relevant

--- a/charts/fcaptcha/templates/_helpers.tpl
+++ b/charts/fcaptcha/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{- define "fcaptcha.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "fcaptcha.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "fcaptcha.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "fcaptcha.labels" -}}
+helm.sh/chart: {{ include "fcaptcha.chart" . }}
+{{ include "fcaptcha.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: fcaptcha
+{{- end }}
+
+{{- define "fcaptcha.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fcaptcha.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "fcaptcha.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "fcaptcha.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+The Secret holding FCAPTCHA_SECRET — either one we create or one the operator
+manages.
+*/}}
+{{- define "fcaptcha.secretName" -}}
+{{- if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ include "fcaptcha.fullname" . }}{{ end }}
+{{- end }}
+
+{{/*
+Refuses to render without a signing key.
+
+The server falls back to `dev-secret-change-in-production`, which is published in
+the source, so a deployment that forgets this does not fail — it silently accepts
+tokens anyone can mint. A template error is the only way to make that impossible
+to do by accident, and it costs one line of setup to satisfy.
+*/}}
+{{- define "fcaptcha.validateSecret" -}}
+{{- if and (not .Values.secret) (not .Values.existingSecret) -}}
+{{- fail "\n\nfcaptcha: a token signing key is required.\n\n  --set secret=$(openssl rand -hex 32)\n\nor point at one you already manage:\n\n  --set existingSecret=my-fcaptcha-secret\n\nWithout it the server falls back to a key published in its own source, and\nanyone can mint tokens your backend will accept.\n" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/fcaptcha/templates/deployment.yaml
+++ b/charts/fcaptcha/templates/deployment.yaml
@@ -1,0 +1,140 @@
+{{- include "fcaptcha.validateSecret" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fcaptcha.fullname" . }}
+  labels:
+    {{- include "fcaptcha.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "fcaptcha.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Rolls pods when the signing key changes. Without this a rotated secret
+        # is only picked up by whatever happens to restart next, leaving pods
+        # signing with different keys and tokens failing verification depending
+        # on which one answered.
+        {{- if not .Values.existingSecret }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "fcaptcha.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "fcaptcha.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: fcaptcha
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.service.targetPort | quote }}
+            - name: FCAPTCHA_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fcaptcha.secretName" . }}
+                  key: {{ .Values.existingSecretKey }}
+            {{- if .Values.verifySecret }}
+            - name: FCAPTCHA_VERIFY_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fcaptcha.secretName" . }}
+                  key: FCAPTCHA_VERIFY_SECRET
+            {{- end }}
+            {{- if .Values.redis.existingSecret }}
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.redis.existingSecret }}
+                  key: {{ .Values.redis.existingSecretKey }}
+            {{- else if .Values.redis.url }}
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "fcaptcha.secretName" . }}
+                  key: REDIS_URL
+            {{- end }}
+            {{- with .Values.config.trustedProxies }}
+            - name: TRUSTED_PROXIES
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.config.allowedHostnames }}
+            - name: FCAPTCHA_ALLOWED_HOSTNAMES
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.config.siteKeys }}
+            - name: FCAPTCHA_SITE_KEYS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if .Values.config.logVerdicts }}
+            - name: FCAPTCHA_LOG_VERDICTS
+              value: "1"
+            {{- end }}
+            {{- if .Values.config.logVerdictsIncludeRaw }}
+            - name: FCAPTCHA_LOG_VERDICTS_INCLUDE_RAW
+              value: "1"
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            # readOnlyRootFilesystem is on, and Go's TLS and DNS paths want a
+            # writable temp dir even when nothing else does.
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/fcaptcha/templates/hpa.yaml
+++ b/charts/fcaptcha/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "fcaptcha.fullname" . }}
+  labels:
+    {{- include "fcaptcha.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "fcaptcha.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/charts/fcaptcha/templates/ingress.yaml
+++ b/charts/fcaptcha/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "fcaptcha.fullname" . }}
+  labels:
+    {{- include "fcaptcha.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "fcaptcha.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/fcaptcha/templates/pdb.yaml
+++ b/charts/fcaptcha/templates/pdb.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "fcaptcha.fullname" . }}
+  labels:
+    {{- include "fcaptcha.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "fcaptcha.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/fcaptcha/templates/secret.yaml
+++ b/charts/fcaptcha/templates/secret.yaml
@@ -1,0 +1,18 @@
+{{- include "fcaptcha.validateSecret" . -}}
+{{- if not .Values.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "fcaptcha.fullname" . }}
+  labels:
+    {{- include "fcaptcha.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  FCAPTCHA_SECRET: {{ .Values.secret | quote }}
+  {{- if .Values.verifySecret }}
+  FCAPTCHA_VERIFY_SECRET: {{ .Values.verifySecret | quote }}
+  {{- end }}
+  {{- if .Values.redis.url }}
+  REDIS_URL: {{ .Values.redis.url | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/fcaptcha/templates/service.yaml
+++ b/charts/fcaptcha/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fcaptcha.fullname" . }}
+  labels:
+    {{- include "fcaptcha.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "fcaptcha.selectorLabels" . | nindent 4 }}

--- a/charts/fcaptcha/templates/serviceaccount.yaml
+++ b/charts/fcaptcha/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "fcaptcha.serviceAccountName" . }}
+  labels:
+    {{- include "fcaptcha.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+# FCaptcha never calls the Kubernetes API; mounting a token would only be
+# credential surface.
+automountServiceAccountToken: false
+{{- end }}

--- a/charts/fcaptcha/templates/tests/test-connection.yaml
+++ b/charts/fcaptcha/templates/tests/test-connection.yaml
@@ -14,12 +14,21 @@ metadata:
     {{- include "fcaptcha.labels" . | nindent 4 }}
   annotations:
     helm.sh/hook: test
-    # before-hook-creation matters as much as hook-succeeded: on its own,
-    # hook-succeeded leaves a *failed* pod behind, and the next `helm test` then
-    # collides with the existing name and re-reports the old failure. That is
-    # indistinguishable from the new run failing, which cost an hour of
-    # debugging a script that was already correct.
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    # before-hook-creation, and deliberately *not* hook-succeeded.
+    #
+    # hook-succeeded alone leaves a failed pod behind, so the next `helm test`
+    # collides with the existing name and re-reports the original failure —
+    # indistinguishable from the new run failing.
+    #
+    # But adding hook-succeeded on top races `helm test --logs`: the pod is
+    # deleted the moment it passes, and fetching its logs then fails with "pods
+    # not found" on an otherwise green run.
+    #
+    # before-hook-creation alone gives both properties. The pod persists after a
+    # run — succeeded or failed — so its logs are retrievable and an operator can
+    # inspect it, and it is cleared out before the next run rather than blocking
+    # it.
+    helm.sh/hook-delete-policy: before-hook-creation
 spec:
   restartPolicy: Never
   automountServiceAccountToken: false

--- a/charts/fcaptcha/templates/tests/test-connection.yaml
+++ b/charts/fcaptcha/templates/tests/test-connection.yaml
@@ -1,0 +1,62 @@
+{{- /*
+`helm test` support, so an operator can verify a release rather than trust it.
+
+Checks more than liveness: /health says the process is up, but the widget URL is
+the one that has actually broken in the wild — the published image returned 404
+for /fcaptcha.js for three months because a path candidate was missing, while
+/health stayed green the whole time.
+*/ -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "fcaptcha.fullname" . }}-test"
+  labels:
+    {{- include "fcaptcha.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: test
+    # before-hook-creation matters as much as hook-succeeded: on its own,
+    # hook-succeeded leaves a *failed* pod behind, and the next `helm test` then
+    # collides with the existing name and re-reports the old failure. That is
+    # indistinguishable from the new run failing, which cost an hour of
+    # debugging a script that was already correct.
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  automountServiceAccountToken: false
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: probe
+      image: curlimages/curl:8.11.1
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop: ["ALL"]
+      args:
+        - /bin/sh
+        - -ec
+        - |
+          BASE="http://{{ include "fcaptcha.fullname" . }}:{{ .Values.service.port }}"
+
+          echo "health"
+          curl -sf "$BASE/health" | grep -q '"ok"'
+
+          echo "widget is served"
+          curl -sf -o /dev/null "$BASE/fcaptcha.js"
+
+          echo "widget declares utf-8 (translations depend on it)"
+          curl -sfI "$BASE/fcaptcha.js" | tr 'A-Z' 'a-z' | grep -q 'charset=utf-8'
+
+          echo "siteverify answers the compat contract"
+          curl -sf -X POST "$BASE/turnstile/v0/siteverify" -d 'response=x' \
+            | grep -q 'missing-input-secret'
+
+          echo "a request with no proof of work is refused a token"
+          curl -sf -X POST "$BASE/api/verify" -H 'Content-Type: application/json' \
+            -d '{"siteKey":"helm-test","signals":{}}' | grep -q '"success":false'
+
+          echo "all checks passed"

--- a/charts/fcaptcha/values.yaml
+++ b/charts/fcaptcha/values.yaml
@@ -1,0 +1,162 @@
+# Default values for the fcaptcha chart.
+
+image:
+  repository: ghcr.io/webdecoy/fcaptcha
+  # Defaults to the chart's appVersion.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+## The token signing key.
+##
+## There is no default, and the chart refuses to render without one. The server's
+## own fallback is `dev-secret-change-in-production`, which is in the public
+## source — a deployment using it can have tokens minted by anyone. Failing to
+## render is the only way to make that impossible to do by accident.
+##
+## Either set `secret` and let the chart create a Secret, or point
+## `existingSecret` at one you manage (sealed-secrets, External Secrets, SOPS).
+secret: ""
+existingSecret: ""
+existingSecretKey: FCAPTCHA_SECRET
+
+## Credential a backend presents when verifying a token. Empty means "same as
+## the signing key", which is the documented default. Splitting them means a
+## leaked verify credential cannot also mint tokens.
+verifySecret: ""
+
+config:
+  ## Peers allowed to set X-Forwarded-For / X-Real-IP / TLS-fingerprint headers.
+  ##
+  ## This matters more in Kubernetes than anywhere else: traffic arrives via an
+  ## Ingress controller, which is a proxy, and if it is not trusted then every
+  ## visitor is attributed to it and rate limiting collapses onto one address.
+  ## The default covers the usual in-cluster pod CIDRs; narrow it to your
+  ## ingress controller's range in production.
+  trustedProxies: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+
+  ## Comma-separated hostnames permitted to mint tokens. Empty accepts any
+  ## origin, which is the right default for a shared or multi-tenant deployment.
+  allowedHostnames: ""
+
+  ## Comma-separated allowlist of accepted site keys. Empty accepts any; the
+  ## per-IP cap on distinct keys applies regardless.
+  siteKeys: ""
+
+  ## One privacy-safe JSON line per verification. Omits IP, user agent and raw
+  ## signals.
+  logVerdicts: false
+
+  ## Additionally logs free-text detection reasons, which can contain
+  ## visitor-derived data (reverse-DNS hostnames, UA fragments, form field ids).
+  ## Do not enable where you have privacy obligations.
+  logVerdictsIncludeRaw: false
+
+## Extra environment variables, for anything the chart does not model.
+extraEnv: []
+# - name: FCAPTCHA_CLIENT_PATH
+#   value: /app/static/fcaptcha.js
+
+## Bundled Redis is deliberately not offered.
+##
+## Shipping a subchart would mean maintaining a database deployment inside a
+## captcha chart, and the honest answer for anything you care about keeping is a
+## managed instance or a purpose-built operator. Point this at one.
+##
+## Note that as of 1.25.0 the servers' Redis support is not implemented — state
+## is in-memory regardless, which is why replicaCount defaults to 1. Setting this
+## is forward-looking.
+redis:
+  url: ""
+  existingSecret: ""
+  existingSecretKey: REDIS_URL
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 3000
+  annotations: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: fcaptcha.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    memory: 512Mi
+
+## Verification is CPU-bound and in-memory, so a pod that is alive is generally
+## ready. The startup probe exists for slow first scheduling on small nodes.
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  periodSeconds: 20
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  periodSeconds: 10
+startupProbe:
+  httpGet:
+    path: /health
+    port: http
+  failureThreshold: 30
+  periodSeconds: 2
+
+## The image runs a single static Go binary and writes nothing to disk.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+topologySpreadConstraints: []
+
+## Off by default because the in-memory stores mean replicas do not share state:
+## a token minted by one pod is unknown to another, so the single-use guard and
+## the rate limiter are per-pod. Enable once Redis-backed state lands, or if you
+## have session affinity and accept the tradeoff.
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1

--- a/server-go/main.go
+++ b/server-go/main.go
@@ -244,7 +244,11 @@ func main() {
 	} else {
 		log.Printf("serving /fcaptcha.js from %s", clientPath)
 	}
-	r.Get("/fcaptcha.js", func(w http.ResponseWriter, r *http.Request) {
+	// GET and HEAD both, because chi's r.Get registers GET alone and a bare HEAD
+	// then answers 405. Caching proxies revalidate with HEAD and uptime monitors
+	// commonly probe with it, so a 405 here reads as an outage on a working
+	// server. http.ServeFile already omits the body for HEAD.
+	serveClient := func(w http.ResponseWriter, r *http.Request) {
 		if clientPath == "" {
 			http.NotFound(w, r)
 			return
@@ -254,11 +258,14 @@ func main() {
 		// strings render as mojibake on any page that is not already UTF-8.
 		w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
 		http.ServeFile(w, r, clientPath)
-	})
+	}
+	r.Get("/fcaptcha.js", serveClient)
+	r.Head("/fcaptcha.js", serveClient)
 	r.Handle("/demo/*", http.StripPrefix("/demo/", http.FileServer(http.Dir("./static/demo"))))
 
 	// Routes
 	r.Get("/health", healthHandler)
+	r.Head("/health", healthHandler)
 	r.Post("/api/verify", verifyHandler(engine, proxyTrust, siteKeys, ja4s))
 	r.Post("/api/score", invisibleScoreHandler(engine, proxyTrust, siteKeys, ja4s))
 	r.Post("/api/token/verify", tokenVerifyHandler(engine, proxyTrust, verifySecret, requireVerifySecret))

--- a/server-python/server.py
+++ b/server-python/server.py
@@ -146,7 +146,11 @@ CLIENT_PATH = os.getenv(
 )
 
 if os.getenv("FCAPTCHA_SERVE_CLIENT", "true").lower() != "false":
-    @app.get("/fcaptcha.js")
+    # GET and HEAD both: Starlette registers only the listed methods, so a bare
+    # HEAD answers 405. Caching proxies revalidate with HEAD and uptime monitors
+    # commonly probe with it, so a 405 here reads as an outage on a working
+    # server.
+    @app.api_route("/fcaptcha.js", methods=["GET", "HEAD"])
     async def fcaptcha_js():
         # charset is not optional here. A classic script served without one is
         # decoded using the *document's* encoding, so the widget's translated
@@ -1691,7 +1695,7 @@ def run_verification(
 # Routes
 # =============================================================================
 
-@app.get("/health")
+@app.api_route("/health", methods=["GET", "HEAD"])
 async def health():
     return {"status": "ok"}
 

--- a/test/test-detection.js
+++ b/test/test-detection.js
@@ -992,6 +992,47 @@ async function testKeystrokeCadence() {
   }
 }
 
+async function testHeadRequests() {
+  log('\n[HEAD requests]', colors.cyan);
+
+  // Caching proxies revalidate with HEAD and uptime monitors commonly probe with
+  // it, so a 405 on a working server reads as an outage. Go and Python both
+  // answered 405 until v1.26.0 — chi's r.Get and Starlette's @app.get each
+  // register the named method only, while Express routes HEAD to its GET
+  // handler, so Node alone was correct and nothing compared them.
+  for (const path of ['/health', '/fcaptcha.js']) {
+    let status = 0;
+    let contentType = '';
+    try {
+      const res = await fetch(`${SERVER_URL}${path}`, { method: 'HEAD' });
+      status = res.status;
+      contentType = res.headers.get('content-type') || '';
+    } catch (e) {
+      status = -1;
+    }
+
+    if (status === 200) {
+      passed++;
+      log(`  ✓ HEAD ${path} is answered`, colors.green);
+    } else {
+      failed++;
+      log(`  ✗ HEAD ${path} returned ${status}`, colors.red);
+    }
+
+    // The widget carries non-ASCII translations, which are decoded using the
+    // document's encoding unless the response says otherwise.
+    if (path === '/fcaptcha.js') {
+      if (/charset=utf-8/i.test(contentType)) {
+        passed++;
+        log(`  ✓ ${path} declares UTF-8`, colors.green);
+      } else {
+        failed++;
+        log(`  ✗ ${path} content-type lacks charset=utf-8: "${contentType}"`, colors.red);
+      }
+    }
+  }
+}
+
 async function testTokenVerification() {
   log('\n[Token Verification]', colors.cyan);
 
@@ -2603,6 +2644,7 @@ async function runTests() {
   await testSignalCommitment();
   await testChallengeNonce();
   await testKeystrokeCadence();
+  await testHeadRequests();
   await testTokenVerification();
   await testInvisibleMode();
 


### PR DESCRIPTION
Two gaps that were awkward for a security project, plus a bug that writing the chart turned up.

## Hygiene

**SECURITY.md** — a security tool with nowhere to send a vulnerability report does not receive them. Names a private channel, sets a response expectation, and is explicit about the difference between *evading a detector* (expected by design, not a vulnerability) and *bypassing the mechanism* (is one), using the v1.23.0 PoW bypass as the worked example.

**CONTRIBUTING.md** — extracts what was buried in the README, plus the two things that actually catch people: detection changes land in all three servers, and the weighted sum means a detector in an under-weighted category can be certain and still never change a verdict.

**CHANGELOG.md** — every release, breaking and security changes called out. Nobody upgrading a security dependency should have to read a diff.

**Templates** — including a dedicated false-positive report, since those are the most valuable reports this project gets.

Also fixes a broken README link: Contributing pointed at `ARCHITECTURE.md`, which does not exist here.

## Helm chart

`artifacthub-repo.yml` had registered a repository ID for months with no chart to publish. Now there is one.

**It refuses to render without a signing key.** The server falls back to `dev-secret-change-in-production`, published in its own source — so a deployment that forgets does not fail, it silently accepts tokens anyone can mint. A template error is the only way to make that impossible by accident.

It also warns on raised `replicaCount` (state is in-memory, so single-use enforcement is per-pod) and on empty `trustedProxies` (behind an ingress controller, every visitor gets attributed to the controller). Security defaults are on and not parameterised down.

Validated by installing it, not just rendering it: `helm lint`, 8 value combinations checked against real Kubernetes schemas with kubeconform (36 resources), then a kind cluster install + `helm test`. CI does the same on every change to `charts/`, `docker/`, `server-go/` or `client/`.

## Fixed: `HEAD` returned 405 on two of three servers

Found by writing a `helm test` that checks the widget declares UTF-8 — which it does with a HEAD request.

chi's `r.Get` and Starlette's `@app.get` each register only the named method; Express routes HEAD to its GET handler. So Node was correct, **Go and Python answered 405** for `/health` and `/fcaptcha.js`, and nothing compared them.

Caching proxies revalidate with HEAD and uptime monitors probe with it, so a 405 reads as an outage on a working server. Fixed in both, with E2E assertions so the three stay in step.

## Fixed: a failed `helm test` blocked every later run

`hook-delete-policy: hook-succeeded` leaves a *failed* pod behind, so the next run collided with the name and re-reported the original failure — indistinguishable from the new run failing. Now `before-hook-creation,hook-succeeded`, and CI runs the test twice to keep it that way.

## Tests

Go race, Node, Python 80, E2E 110/110 (+3 HEAD assertions), browser 24/24.