### PR TITLE
fix(node): enforce proof of work in library API

### DIFF
--- a/server-node/index.js
+++ b/server-node/index.js
@@ -246,6 +246,7 @@ class ScoringEngine {
   // Verify signals and return score
   verify(signals, ip, siteKey, userAgent, headers = {}, powSolution = null) {
     const detections = [];
+    let powSatisfied = false;
 
     // Run all detection modules
     detections.push(...this._detectVisionAI(signals));
@@ -272,6 +273,7 @@ class ScoringEngine {
           reason: `PoW verification failed: ${powResult.reason}`
         });
       } else if (powResult.serverElapsed < BASE_MIN_AGE_MS) {
+        powSatisfied = true;
         // Under the universal baseline nothing legitimate can have happened —
         // no human completes an interaction that fast.
         detections.push({
@@ -281,6 +283,7 @@ class ScoringEngine {
           reason: `Challenge solved too fast (${powResult.serverElapsed}ms server-side)`
         });
       } else if (powResult.serverElapsed < powResult.minAgeMs) {
+        powSatisfied = true;
         // Between the baseline and this source's own elevated floor is weaker
         // evidence: a client predating adaptive cost, or one served from a
         // stale cache, does not know to wait. It contributes rather than
@@ -291,6 +294,8 @@ class ScoringEngine {
           confidence: 0.5,
           reason: `Challenge submitted before the required delay for this source (${powResult.serverElapsed}ms of ${powResult.minAgeMs}ms)`
         });
+      } else {
+        powSatisfied = true;
       }
     } else {
       detections.push({
@@ -336,7 +341,12 @@ class ScoringEngine {
     else if (finalScore < 0.6) recommendation = 'challenge';
     else recommendation = 'block';
 
-    const success = finalScore < 0.5;
+    // PoW is a precondition, not weighted evidence. Expressing a missing or
+    // invalid solution only as a bot-category score lets the category weight
+    // dilute it below the allow threshold and used to mint a token for an empty
+    // request. Keep this gate independent of scoring so weight changes cannot
+    // reopen the bypass.
+    const success = finalScore < 0.5 && powSatisfied;
     const token = success ? this._generateToken(ip, siteKey, finalScore) : null;
 
     // Feed the ledger so the next challenge this source asks for is priced on
@@ -350,7 +360,8 @@ class ScoringEngine {
       timestamp: Math.floor(Date.now() / 1000),
       recommendation,
       categoryScores,
-      detections
+      detections,
+      ...(!powSatisfied ? { reason: 'pow_not_satisfied' } : {})
     };
   }
 

--- a/server-node/index.test.js
+++ b/server-node/index.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const assert = require('assert');
+const crypto = require('crypto');
+const { createScoringEngine } = require('./index');
+
+function solve(challenge) {
+  for (let nonce = 0; ; nonce++) {
+    const hash = crypto.createHash('sha256')
+      .update(`${challenge.prefix}:${nonce}`)
+      .digest('hex');
+    if (hash.startsWith('0'.repeat(challenge.difficulty))) {
+      return { challengeId: challenge.id, nonce, hash };
+    }
+  }
+}
+
+const cleanSignals = {
+  behavioral: { microTremorScore: 0.5, approachDirectness: 0.4 },
+  environmental: { automationFlags: {} }
+};
+const cleanHeaders = {
+  accept: 'text/html',
+  'accept-language': 'en-US,en;q=0.9',
+  'accept-encoding': 'gzip, deflate, br',
+  connection: 'keep-alive'
+};
+
+{
+  const engine = createScoringEngine({ secret: 'test-secret' });
+  const result = engine.verify({}, '203.0.113.1', 'site', '', {}, null);
+  assert.strictEqual(result.success, false, 'missing PoW must not succeed');
+  assert.strictEqual(result.token, null, 'missing PoW must not mint a token');
+  assert.strictEqual(result.reason, 'pow_not_satisfied');
+}
+
+{
+  const engine = createScoringEngine({ secret: 'test-secret' });
+  const result = engine.verify(cleanSignals, '203.0.113.1', 'site', 'Mozilla/5.0', cleanHeaders, {
+    challengeId: 'not-issued', nonce: 0, hash: '0'.repeat(64)
+  });
+  assert.strictEqual(result.success, false, 'invalid PoW must not succeed');
+  assert.strictEqual(result.token, null, 'invalid PoW must not mint a token');
+}
+
+{
+  const engine = createScoringEngine({ secret: 'test-secret' });
+  const challenge = engine.generateChallenge('site', '203.0.113.1', {
+    difficulty: 1,
+    scaleByReputation: false
+  });
+  // This unit test exercises the hard gate, not the elapsed-time heuristic.
+  challenge.timestamp -= 2000;
+  engine.powStore.challenges.get(challenge.id).timestamp -= 2000;
+  const result = engine.verify(
+    cleanSignals,
+    '203.0.113.1',
+    'site',
+    'Mozilla/5.0',
+    cleanHeaders,
+    solve(challenge)
+  );
+  assert.strictEqual(result.success, true, 'valid PoW may succeed');
+  assert.ok(result.token, 'valid PoW may mint a token');
+}
+
+console.log('index.js security gate tests passed');

--- a/server-node/package.json
+++ b/server-node/package.json
@@ -15,7 +15,7 @@
     "test:clientip": "node clientip.test.js",
     "test:limits": "node limits.test.js",
     "test:detection": "node detection.test.js",
-    "test": "node clientip.test.js && node limits.test.js && node detection.test.js && node inputforensics.test.js && node webbotauth.test.js && node siteverify.test.js && node --test suspicion.test.js",
+    "test": "node clientip.test.js && node limits.test.js && node detection.test.js && node inputforensics.test.js && node webbotauth.test.js && node siteverify.test.js && node index.test.js && node --test suspicion.test.js",
     "test:siteverify": "node siteverify.test.js",
     "test:forensics": "node inputforensics.test.js",
     "test:suspicion": "node --test suspicion.test.js"


### PR DESCRIPTION
## Summary

- require a successfully verified proof of work before the exported Node ScoringEngine can issue a token
- return pow_not_satisfied for missing or invalid proofs
- add regression tests for missing, invalid, and valid proofs to the standard Node test suite

## Why

The HTTP servers enforce proof of work as a hard precondition, but the npm package primary index.js export only treated failure as weighted evidence. Because the bot category weight is below the allow threshold, an empty request without a proof could receive a token.

## Validation

- cd server-node and run npm test
- git diff --check

All Node tests pass.