### PR TITLE
docs: state single-instance deployment limits

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -28,11 +28,10 @@ This guide covers installing and deploying FCaptcha for development and producti
 |----------|---------|-------|
 | Node.js | 18+ | Recommended: 20 LTS |
 | Python | 3.10+ | Recommended: 3.12 |
-| Go | 1.21+ | Recommended: 1.22 |
+| Go | 1.24+ | Required for native JA4 support |
 
 ### Optional
 
-- **Redis** - For distributed state in multi-instance deployments
 - **Docker** - For containerized deployment
 - **Nginx/Caddy** - For reverse proxy and TLS termination
 
@@ -254,7 +253,7 @@ docker run -d \
   fcaptcha-go
 ```
 
-### Docker Compose (with Redis)
+### Docker Compose (single instance)
 
 Create `docker-compose.yml`:
 
@@ -268,20 +267,11 @@ services:
       - "3000:3000"
     environment:
       - FCAPTCHA_SECRET=your-secret-key-here
-      - REDIS_URL=redis://redis:6379
-    depends_on:
-      - redis
     restart: unless-stopped
-
-  redis:
-    image: redis:7-alpine
-    volumes:
-      - redis_data:/data
-    restart: unless-stopped
-
-volumes:
-  redis_data:
 ```
+
+FCaptcha state is process-local. `REDIS_URL` is reserved but currently unused,
+so run a single instance until the distributed-state backend is implemented.
 
 Run:
 
@@ -430,11 +420,8 @@ server {
 }
 ```
 
-**Important:** When running multiple instances, use Redis for shared state:
-
-```bash
-export REDIS_URL=redis://localhost:6379
-```
+**Important:** Do not run multiple instances yet. Server state is process-local;
+Redis-backed shared state is planned but not implemented.
 
 ---
 
@@ -449,7 +436,7 @@ export REDIS_URL=redis://localhost:6379
 | `FCAPTCHA_LEGACY_UNAUTH_VERIFY` | No | off | Restore the pre-1.22.0 behaviour where token verification accepted any caller. Migration cover for one release — see [Upgrading to 1.22.0](#upgrading-to-1220) |
 | `FCAPTCHA_ALLOWED_HOSTNAMES` | No | (any) | Comma-separated hostnames permitted to mint tokens, matched against the request `Origin` (then `Referer`) |
 | `PORT` | No | 3000 | Server port |
-| `REDIS_URL` | No | - | Redis URL for distributed state |
+| `REDIS_URL` | No | - | Reserved; distributed state is not implemented yet |
 | `NODE_ENV` | No | development | Set to `production` for Node.js |
 | `TRUSTED_PROXIES` | No | loopback + private ranges | Peers allowed to set `X-Forwarded-For` / `X-Real-IP` / TLS-fingerprint headers. See [Trusted proxies](#trusted-proxies) |
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,16 @@ This gives you:
 - Client JS at `http://localhost:3000/fcaptcha.js`
 - Demo page at `http://localhost:3000/demo/`
 
-With Redis (for distributed state):
+Docker Compose (single instance):
 
 ```bash
 FCAPTCHA_SECRET=my-secret docker compose -f docker/docker-compose.yml up -d
 ```
+
+FCaptcha state is currently process-local. `REDIS_URL` is reserved for a future
+distributed-state backend and is not read by the servers yet. Run one server
+instance only: multiple replicas do not share challenges, replay protection,
+rate limits, suspicion history, or idempotency results.
 
 Kubernetes:
 
@@ -122,7 +127,7 @@ Two options, and the tradeoff is real:
 
 <!-- CDN: no server needed to try it, pinned and integrity-checked. -->
 <script
-  src="https://cdn.jsdelivr.net/npm/@webdecoy/fcaptcha-client@1.24.0/dist/fcaptcha.min.js"
+  src="https://cdn.jsdelivr.net/npm/@webdecoy/fcaptcha-client@1.28.1/dist/fcaptcha.min.js"
   integrity="sha384-…"
   crossorigin="anonymous"></script>
 ```
@@ -759,7 +764,7 @@ Set `action` (and optionally `cdata`) when you request the token —
 | `FCAPTCHA_LEGACY_UNAUTH_VERIFY` | Restore the pre-1.22.0 behaviour where token verification accepted any caller. One release of migration cover; **do not leave it on** | off |
 | `FCAPTCHA_ALLOWED_HOSTNAMES` | Comma-separated hostnames permitted to mint tokens, matched against the request's `Origin` (then `Referer`). Unset accepts any origin. A request with no derivable origin (native app, server-side call) is always allowed — an attacker who can forge an `Origin` would just forge a listed one | (any) |
 | `PORT` | Server port | 3000 |
-| `REDIS_URL` | Redis URL for distributed state | (in-memory) |
+| `REDIS_URL` | Reserved; distributed state is not implemented yet | (unused) |
 | `TRUSTED_PROXIES` | Comma-separated CIDRs/IPs of peers allowed to set `X-Forwarded-For`, `X-Real-IP` and the TLS-fingerprint headers. `*` trusts every peer, `none` trusts none. See [Trusted proxies](#trusted-proxies) | loopback + private ranges |
 | `FCAPTCHA_SITE_KEYS` | Comma-separated allowlist of accepted site keys. Unset accepts any key (zero-config self-hosting); unlisted keys are folded into a shared overflow bucket rather than allocating their own rate-limit/fingerprint state | (any) |
 | `FCAPTCHA_MAX_SITE_KEYS_PER_IP` | Distinct site keys one IP may allocate state for before the excess is folded into the overflow bucket. The cap itself is unconditional | 8 |
@@ -886,7 +891,7 @@ fcaptcha/
 │   └── index.html           # Interactive demo page
 ├── docker/
 │   ├── Dockerfile           # Multi-stage build (Go binary + client + demo)
-│   └── docker-compose.yml   # Docker compose with Redis
+│   └── docker-compose.yml   # Single-instance Docker Compose deployment
 ├── .github/workflows/
 │   ├── bench.yml            # Unit tests + E2E + gated detection benchmark
 │   ├── docker-publish.yml   # GHCR publish on release

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,26 +11,9 @@ services:
     environment:
       - FCAPTCHA_SECRET=${FCAPTCHA_SECRET:-change-me-in-production}
       - PORT=3000
-      - REDIS_URL=redis://redis:6379
-    depends_on:
-      - redis
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/health"]
       interval: 30s
       timeout: 3s
       retries: 3
-
-  redis:
-    image: redis:7-alpine
-    volumes:
-      - redis-data:/data
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 3s
-      retries: 3
-
-volumes:
-  redis-data:


### PR DESCRIPTION
## Summary

- remove the unused Redis service from Docker Compose
- document that challenges, replay guards, rate limits, suspicion history, and idempotency are process-local
- mark REDIS_URL as reserved rather than functional
- align the Go requirement with go.mod
- update the pinned client example to version 1.28.1

## Why

The existing quick starts described Redis as a distributed-state backend even though none of the servers use it. That could encourage multi-replica deployments with inconsistent challenge and replay state.

## Validation

- git diff --check
- searched the deployment documentation for stale Redis and version claims

Docker Compose validation was not available locally because this Docker installation does not include the Compose subcommand; CI validates the repository deployment assets.