### PR TITLE
fix(server): bound public request bodies

### DIFF
--- a/server-go/bodylimit_test.go
+++ b/server-go/bodylimit_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRequestBodyLimit(t *testing.T) {
+	called := false
+	h := limitRequestBody(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	tooLarge := strings.NewReader(strings.Repeat("x", int(maxRequestBodyBytes)+1))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/verify", tooLarge))
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized body: got status %d, want 413", w.Code)
+	}
+	if called {
+		t.Fatal("oversized body reached the application handler")
+	}
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/verify", strings.NewReader("{}")))
+	if w.Code != http.StatusNoContent || !called {
+		t.Fatalf("small body did not reach handler: status=%d called=%v", w.Code, called)
+	}
+}

--- a/server-go/main.go
+++ b/server-go/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
+	"io"
 	"log"
 	"net/http"
 	_ "net/http/pprof"
@@ -21,6 +23,33 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 )
+
+const maxRequestBodyBytes int64 = 64 * 1024
+
+// limitRequestBody rejects oversized requests before JSON or form decoding.
+// Reading at most limit+1 bytes keeps the memory bound explicit and lets every
+// handler, including the compatibility endpoints, return the same 413 status.
+func limitRequestBody(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+		body, err := io.ReadAll(io.LimitReader(r.Body, maxRequestBodyBytes+1))
+		if err != nil {
+			http.Error(w, "Invalid request body", http.StatusBadRequest)
+			return
+		}
+		if int64(len(body)) > maxRequestBodyBytes {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			json.NewEncoder(w).Encode(map[string]string{"error": "request_too_large"})
+			return
+		}
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		next.ServeHTTP(w, r)
+	})
+}
 
 // resolveClientPath finds fcaptcha.js at startup so the widget can be served
 // from the same origin as the API (matches the Node and Python servers).
@@ -224,6 +253,7 @@ func main() {
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Timeout(30 * time.Second))
+	r.Use(limitRequestBody)
 
 	// CORS for widget
 	r.Use(cors.Handler(cors.Options{

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -27,11 +27,14 @@ const {
 
 const app = express();
 app.use(cors());
-app.use(express.json());
+// Captured widget payloads are about 10-15 KiB. Four times that leaves ample
+// room for future signals while bounding work done by the public JSON parsers.
+const MAX_REQUEST_BODY_BYTES = 64 * 1024;
+app.use(express.json({ limit: MAX_REQUEST_BODY_BYTES }));
 // The siteverify contract accepts form-encoded bodies as well as JSON, and most
 // PHP and Python integrations in the wild post form-encoded. Parsing both here
 // costs nothing on the JSON path.
-app.use(express.urlencoded({ extended: false }));
+app.use(express.urlencoded({ extended: false, limit: MAX_REQUEST_BODY_BYTES }));
 
 const SECRET_KEY = process.env.FCAPTCHA_SECRET || 'dev-secret-change-in-production';
 
@@ -1785,6 +1788,16 @@ app.get('/api/challenge', (req, res) => {
     powDifficulty: 4,
     expires: Math.floor(Date.now() / 1000) + 300
   });
+});
+
+// Express identifies parser limit failures with status 413 / entity.too.large.
+// Handle them explicitly so all three servers expose the same status instead
+// of falling through to Express's HTML error response.
+app.use((err, req, res, next) => {
+  if (err && (err.status === 413 || err.type === 'entity.too.large')) {
+    return res.status(413).json({ error: 'request_too_large' });
+  }
+  return next(err);
 });
 
 // =============================================================================

--- a/server-python/server.py
+++ b/server-python/server.py
@@ -42,6 +42,72 @@ from suspicion import (
 # Keep in sync with server-node/package.json and client/fcaptcha.js on release.
 app = FastAPI(title="FCaptcha", version="1.28.1")
 
+MAX_REQUEST_BODY_BYTES = 64 * 1024
+
+
+class RequestBodyLimitMiddleware:
+    """Reject oversized request bodies before FastAPI parses JSON or forms."""
+
+    def __init__(self, app, max_bytes: int = MAX_REQUEST_BODY_BYTES):
+        self.app = app
+        self.max_bytes = max_bytes
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        content_length = next(
+            (value for name, value in scope.get("headers", []) if name.lower() == b"content-length"),
+            None,
+        )
+        if content_length is not None:
+            try:
+                if int(content_length) > self.max_bytes:
+                    await self._reject(send)
+                    return
+            except ValueError:
+                pass
+
+        body = bytearray()
+        more_body = True
+        while more_body:
+            message = await receive()
+            if message["type"] == "http.disconnect":
+                return
+            body.extend(message.get("body", b""))
+            if len(body) > self.max_bytes:
+                await self._reject(send)
+                return
+            more_body = message.get("more_body", False)
+
+        delivered = False
+
+        async def replay():
+            nonlocal delivered
+            if delivered:
+                return {"type": "http.request", "body": b"", "more_body": False}
+            delivered = True
+            return {"type": "http.request", "body": bytes(body), "more_body": False}
+
+        await self.app(scope, replay, send)
+
+    @staticmethod
+    async def _reject(send):
+        payload = b'{"error":"request_too_large"}'
+        await send({
+            "type": "http.response.start",
+            "status": 413,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(payload)).encode()),
+            ],
+        })
+        await send({"type": "http.response.body", "body": payload})
+
+
+app.add_middleware(RequestBodyLimitMiddleware)
+
 # Which peers may speak for another client via X-Forwarded-For / X-Real-IP and
 # the TLS-fingerprint headers. See clientip.py.
 PROXY_TRUST = ProxyTrust.from_env()

--- a/server-python/test_bodylimits.py
+++ b/server-python/test_bodylimits.py
@@ -1,0 +1,72 @@
+import asyncio
+import unittest
+
+from server import MAX_REQUEST_BODY_BYTES, RequestBodyLimitMiddleware
+
+
+class RequestBodyLimitTests(unittest.TestCase):
+    def _run(self, body: bytes, content_length=True):
+        called = False
+        sent = []
+
+        async def downstream(scope, receive, send):
+            nonlocal called
+            called = True
+            message = await receive()
+            self.assertEqual(message["body"], body)
+
+        headers = []
+        if content_length:
+            headers.append((b"content-length", str(len(body)).encode()))
+        scope = {"type": "http", "headers": headers}
+        messages = iter([{"type": "http.request", "body": body, "more_body": False}])
+
+        async def receive():
+            return next(messages)
+
+        async def send(message):
+            sent.append(message)
+
+        asyncio.run(RequestBodyLimitMiddleware(downstream)(scope, receive, send))
+        return called, sent
+
+    def test_rejects_declared_oversized_body(self):
+        called, sent = self._run(b"x", content_length=False)
+        self.assertTrue(called)
+        self.assertEqual(sent, [])
+
+        async def run_declared():
+            called = False
+            sent = []
+
+            async def downstream(scope, receive, send):
+                nonlocal called
+                called = True
+
+            async def receive():
+                raise AssertionError("body should not be read")
+
+            async def send(message):
+                sent.append(message)
+
+            scope = {"type": "http", "headers": [(b"content-length", str(MAX_REQUEST_BODY_BYTES + 1).encode())]}
+            await RequestBodyLimitMiddleware(downstream)(scope, receive, send)
+            return called, sent
+
+        called, sent = asyncio.run(run_declared())
+        self.assertFalse(called)
+        self.assertEqual(sent[0]["status"], 413)
+
+    def test_rejects_chunked_oversized_body(self):
+        called, sent = self._run(b"x" * (MAX_REQUEST_BODY_BYTES + 1), content_length=False)
+        self.assertFalse(called)
+        self.assertEqual(sent[0]["status"], 413)
+
+    def test_allows_small_body(self):
+        called, sent = self._run(b"{}")
+        self.assertTrue(called)
+        self.assertEqual(sent, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test-detection.js
+++ b/test/test-detection.js
@@ -88,6 +88,22 @@ async function makeVerifiedRequest(options = {}) {
   return makeRequest('/api/verify', { ...options, body: { ...requested, ...body } });
 }
 
+async function testRequestBodyLimit() {
+  log('Request body limits:', colors.cyan);
+  const response = await fetch(`${SERVER_URL}/api/verify`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ padding: 'x'.repeat(64 * 1024) }),
+  });
+  if (response.status === 413) {
+    passed++;
+    log('  ✓ Oversized request rejected with 413', colors.green);
+  } else {
+    failed++;
+    log(`  ✗ Oversized request returned ${response.status}, expected 413`, colors.red);
+  }
+}
+
 function assertDetection(result, category, shouldDetect, testName) {
   const detections = result.detections || [];
   const hasCategory = detections.some(d => d.category === category);
@@ -2647,6 +2663,7 @@ async function runTests() {
   await testHeadRequests();
   await testTokenVerification();
   await testInvisibleMode();
+  await testRequestBodyLimit();
 
   // Summary
   log(`\n${colors.bold}═══════════════════════════════════════${colors.reset}`);


### PR DESCRIPTION
## Summary

- cap request bodies at 64 KiB in Go, Node, and Python
- reject oversized JSON and form bodies before application parsing
- return HTTP 413 with a consistent request_too_large JSON error
- cover declared-length and chunked oversized requests
- add an end-to-end invariant shared by all three server implementations

## Limit selection

Committed browser traces are approximately 10-15 KiB. A 64 KiB ceiling leaves more than four times the current maximum while bounding memory and parsing work on public endpoints.

## Validation

- Node unit suite passes
- live Node endpoint returns JSON 413 for oversized verification input
- all 83 Python tests pass
- git diff --check passes
- Go unit coverage was added; Go is unavailable locally and the Go 1.24 CI job will run it