### PR TITLE
fix(config): require an explicit signing secret

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Start server
         working-directory: server-node
+        env:
+          FCAPTCHA_SECRET: benchmark-test-secret
         run: |
           node server.js &
           for _ in $(seq 1 40); do
@@ -43,6 +45,8 @@ jobs:
           echo "server did not come up"; exit 1
 
       - name: End-to-end detection suite
+        env:
+          FCAPTCHA_SECRET: benchmark-test-secret
         run: node test/test-detection.js
 
       # The widget in a real browser: the proof-of-work solver, and everything

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Start
         run: |
-          docker run -d --name smoke -p 3000:3000 smoke-img
+          docker run -d --name smoke -p 3000:3000 -e FCAPTCHA_SECRET=container-smoke-test-secret smoke-img
           for _ in $(seq 1 60); do
             curl -sf http://localhost:3000/health >/dev/null && exit 0
             sleep 0.5

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -64,4 +64,6 @@ jobs:
       # report 12 tests and two import errors where there are in fact 43.
       - name: Test
         working-directory: server-python
+        env:
+          FCAPTCHA_SECRET: python-unit-test-secret
         run: python -m unittest discover -p "test_*.py" -v

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -49,7 +49,7 @@ cd fcaptcha
 # Start the Node.js server (easiest)
 cd server-node
 npm install
-node server.js
+FCAPTCHA_SECRET=local-development-secret node server.js
 
 # Server is now running at http://localhost:3000
 ```
@@ -432,6 +432,7 @@ Redis-backed shared state is planned but not implemented.
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `FCAPTCHA_SECRET` | Yes | - | Secret key for signing tokens (min 16 chars) |
+| `FCAPTCHA_INSECURE_DEV_MODE` | No | off | Explicitly use the public development signing key for local-only development. Never expose a server with this enabled |
 | `FCAPTCHA_VERIFY_SECRET` | No | `FCAPTCHA_SECRET` | Credential your backend sends as `secret` when verifying a token. Split it from the signing key so a leaked verify credential cannot also mint tokens |
 | `FCAPTCHA_LEGACY_UNAUTH_VERIFY` | No | off | Restore the pre-1.22.0 behaviour where token verification accepted any caller. Migration cover for one release — see [Upgrading to 1.22.0](#upgrading-to-1220) |
 | `FCAPTCHA_ALLOWED_HOSTNAMES` | No | (any) | Comma-separated hostnames permitted to mint tokens, matched against the request `Origin` (then `Referer`) |

--- a/README.md
+++ b/README.md
@@ -760,6 +760,7 @@ Set `action` (and optionally `cdata`) when you request the token —
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `FCAPTCHA_SECRET` | Secret key for token signing | (required) |
+| `FCAPTCHA_INSECURE_DEV_MODE` | Explicitly use the public development signing key. Local-only escape hatch; never expose a server with this enabled | off |
 | `FCAPTCHA_VERIFY_SECRET` | Credential a backend presents to `/api/token/verify` and the siteverify endpoints. Split it from `FCAPTCHA_SECRET` so a leaked verify credential cannot also mint tokens | (`FCAPTCHA_SECRET`) |
 | `FCAPTCHA_LEGACY_UNAUTH_VERIFY` | Restore the pre-1.22.0 behaviour where token verification accepted any caller. One release of migration cover; **do not leave it on** | off |
 | `FCAPTCHA_ALLOWED_HOSTNAMES` | Comma-separated hostnames permitted to mint tokens, matched against the request's `Origin` (then `Referer`). Unset accepts any origin. A request with no derivable origin (native app, server-side call) is always allowed — an attacker who can forge an `Origin` would just forge a listed one | (any) |
@@ -907,13 +908,13 @@ fcaptcha/
 
 ```bash
 # Run Go server
-cd server-go && go run .
+cd server-go && FCAPTCHA_SECRET=local-development-secret go run .
 
 # Run Python server
-cd server-python && python server.py
+cd server-python && FCAPTCHA_SECRET=local-development-secret python server.py
 
 # Run Node server
-cd server-node && node server.js
+cd server-node && FCAPTCHA_SECRET=local-development-secret node server.js
 
 # Open demo
 open demo/index.html
@@ -945,7 +946,7 @@ End-to-end detection suite (runs against a live server):
 
 ```bash
 # Start a server first (any language)
-cd server-node && node server.js &
+cd server-node && FCAPTCHA_SECRET=fcaptcha-test-suite-secret node server.js &
 
 # Run the suite
 node test/test-detection.js

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -89,9 +89,10 @@ is, older lines are not maintained — upgrade rather than expect a backport.
 Several ways to make a correct build insecure, documented because they are easy
 to get wrong and fail quietly:
 
-- **`FCAPTCHA_SECRET`** signs every token. Set it. The default,
-  `dev-secret-change-in-production`, is in the source and therefore public — a
-  deployment using it can have tokens minted by anyone.
+- **`FCAPTCHA_SECRET`** signs every token and is required. Servers refuse to
+  start without it or when it equals the public development key. The explicit
+  `FCAPTCHA_INSECURE_DEV_MODE=1` escape hatch exists only for local development;
+  a deployment using it can have tokens minted by anyone.
 - **`TRUSTED_PROXIES`** decides whose `X-Forwarded-For` is believed. Left
   unset behind a proxy, every visitor is attributed to the proxy and rate
   limiting collapses onto one address. Set wrong, a client can claim any IP.

--- a/bench/README.md
+++ b/bench/README.md
@@ -9,7 +9,7 @@ that makes those claims checkable, including when they turn out to be wrong.
 
 ```bash
 # 1. start any server
-cd ../server-node && npm start        # or server-go: go run .   /   server-python: python server.py
+cd ../server-node && FCAPTCHA_SECRET=benchmark-test-secret npm start
 
 # 2. record the corpus from a real browser (one-time; commit the result)
 cd ../bench && npm install && npm run install-browsers

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-      - FCAPTCHA_SECRET=${FCAPTCHA_SECRET:-change-me-in-production}
+      - FCAPTCHA_SECRET=${FCAPTCHA_SECRET:?Set FCAPTCHA_SECRET before starting FCaptcha}
       - PORT=3000
     restart: unless-stopped
     healthcheck:

--- a/server-go/config_test.go
+++ b/server-go/config_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+func configEnv(values map[string]string) func(string) string {
+	return func(key string) string { return values[key] }
+}
+
+func TestSigningSecretFailsClosed(t *testing.T) {
+	for _, values := range []map[string]string{
+		{},
+		{"FCAPTCHA_SECRET": insecureDefaultSecret},
+	} {
+		if _, err := signingSecretFromEnv(configEnv(values)); err == nil {
+			t.Fatalf("configuration %v should fail", values)
+		}
+	}
+}
+
+func TestSigningSecretAcceptsConfiguredSecret(t *testing.T) {
+	got, err := signingSecretFromEnv(configEnv(map[string]string{"FCAPTCHA_SECRET": "a-real-deployment-secret"}))
+	if err != nil || got != "a-real-deployment-secret" {
+		t.Fatalf("got secret=%q err=%v", got, err)
+	}
+}
+
+func TestSigningSecretExplicitDevelopmentMode(t *testing.T) {
+	got, err := signingSecretFromEnv(configEnv(map[string]string{"FCAPTCHA_INSECURE_DEV_MODE": "yes"}))
+	if err != nil || got != insecureDefaultSecret {
+		t.Fatalf("got secret=%q err=%v", got, err)
+	}
+}

--- a/server-go/main.go
+++ b/server-go/main.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -134,6 +135,21 @@ func envFlagEnabled(key string) bool {
 	}
 }
 
+const insecureDefaultSecret = "dev-secret-change-in-production"
+
+func signingSecretFromEnv(getenv func(string) string) (string, error) {
+	secret := strings.TrimSpace(getenv("FCAPTCHA_SECRET"))
+	if secret != "" && secret != insecureDefaultSecret {
+		return secret, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(getenv("FCAPTCHA_INSECURE_DEV_MODE"))) {
+	case "1", "true", "yes", "on":
+		log.Printf("WARNING: FCAPTCHA_INSECURE_DEV_MODE enabled; tokens use a public signing key. Never expose this server to a network.")
+		return insecureDefaultSecret, nil
+	}
+	return "", fmt.Errorf("FCAPTCHA_SECRET is required and must not be the public development key; for local-only development, explicitly set FCAPTCHA_INSECURE_DEV_MODE=1")
+}
+
 // logVerdict emits one privacy-safe JSON line describing a scoring outcome.
 // No-op unless verdict logging is enabled. Omits IP, user agent, and raw signals;
 // the free-text detection Reason is included only when verdictLogIncludeRaw is set.
@@ -176,9 +192,9 @@ func main() {
 	log.SetOutput(os.Stdout)
 
 	// Configuration
-	secretKey := os.Getenv("FCAPTCHA_SECRET")
-	if secretKey == "" {
-		secretKey = "dev-secret-change-in-production"
+	secretKey, err := signingSecretFromEnv(os.Getenv)
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	// The credential a backend presents to validate a token. Defaults to the

--- a/server-node/config.js
+++ b/server-node/config.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const INSECURE_DEFAULT_SECRET = 'dev-secret-change-in-production';
+
+function signingSecretFromEnv(env = process.env) {
+  const secret = String(env.FCAPTCHA_SECRET || '').trim();
+  if (secret && secret !== INSECURE_DEFAULT_SECRET) return secret;
+  if (/^(1|true|yes|on)$/i.test(String(env.FCAPTCHA_INSECURE_DEV_MODE || '').trim())) {
+    console.warn('WARNING: FCAPTCHA_INSECURE_DEV_MODE enabled; tokens use a public signing key. Never expose this server to a network.');
+    return INSECURE_DEFAULT_SECRET;
+  }
+  throw new Error('FCAPTCHA_SECRET is required and must not be the public development key. For local-only development, explicitly set FCAPTCHA_INSECURE_DEV_MODE=1.');
+}
+
+function signingSecret(explicit, env = process.env) {
+  if (explicit !== undefined && explicit !== null) {
+    return signingSecretFromEnv({ ...env, FCAPTCHA_SECRET: explicit });
+  }
+  return signingSecretFromEnv(env);
+}
+
+module.exports = { INSECURE_DEFAULT_SECRET, signingSecret, signingSecretFromEnv };

--- a/server-node/config.test.js
+++ b/server-node/config.test.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const assert = require('assert');
+const { INSECURE_DEFAULT_SECRET, signingSecret, signingSecretFromEnv } = require('./config');
+
+assert.throws(() => signingSecretFromEnv({}), /FCAPTCHA_SECRET is required/);
+assert.throws(() => signingSecretFromEnv({ FCAPTCHA_SECRET: INSECURE_DEFAULT_SECRET }), /FCAPTCHA_SECRET is required/);
+assert.strictEqual(signingSecretFromEnv({ FCAPTCHA_SECRET: 'a-real-deployment-secret' }), 'a-real-deployment-secret');
+assert.strictEqual(signingSecretFromEnv({ FCAPTCHA_INSECURE_DEV_MODE: 'true' }), INSECURE_DEFAULT_SECRET);
+assert.strictEqual(signingSecret('explicit-library-secret', {}), 'explicit-library-secret');
+assert.throws(() => signingSecret(undefined, {}), /FCAPTCHA_SECRET is required/);
+
+console.log('signing-secret configuration tests passed');

--- a/server-node/index.js
+++ b/server-node/index.js
@@ -13,6 +13,7 @@ const crypto = require('crypto');
 const detection = require('./detection');
 const { ProxyTrust } = require('./clientip');
 const { SuspicionLedger, computeChallengeCost, BASE_MIN_AGE_MS } = require('./suspicion');
+const { signingSecret } = require('./config');
 
 // =============================================================================
 // PoW Challenge Store (can be extended with Redis)
@@ -20,7 +21,7 @@ const { SuspicionLedger, computeChallengeCost, BASE_MIN_AGE_MS } = require('./su
 
 class PoWChallengeStore {
   constructor(options = {}) {
-    this.secret = options.secret || 'dev-secret-change-in-production';
+    this.secret = signingSecret(options.secret);
     this.challenges = new Map();
     this.usedSolutions = new Set();
     this.expirationMs = options.expirationMs || 5 * 60 * 1000; // 5 minutes
@@ -212,7 +213,7 @@ const AUTOMATION_UA_PATTERNS = [
 
 class ScoringEngine {
   constructor(options = {}) {
-    this.secret = options.secret || 'dev-secret-change-in-production';
+    this.secret = signingSecret(options.secret);
     this.powStore = options.powStore || new PoWChallengeStore({ secret: this.secret });
     this.rateLimiter = options.rateLimiter || new RateLimiter();
     this.fingerprintStore = options.fingerprintStore || new FingerprintStore();

--- a/server-node/package.json
+++ b/server-node/package.json
@@ -15,7 +15,7 @@
     "test:clientip": "node clientip.test.js",
     "test:limits": "node limits.test.js",
     "test:detection": "node detection.test.js",
-    "test": "node clientip.test.js && node limits.test.js && node detection.test.js && node inputforensics.test.js && node webbotauth.test.js && node siteverify.test.js && node index.test.js && node --test suspicion.test.js",
+    "test": "node config.test.js && node clientip.test.js && node limits.test.js && node detection.test.js && node inputforensics.test.js && node webbotauth.test.js && node siteverify.test.js && node index.test.js && node --test suspicion.test.js",
     "test:siteverify": "node siteverify.test.js",
     "test:forensics": "node inputforensics.test.js",
     "test:suspicion": "node --test suspicion.test.js"

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -12,6 +12,7 @@ const detection = require('./detection');
 const webbotauth = require('./webbotauth');
 const { ProxyTrust } = require('./clientip');
 const { BoundedMap, BoundedSet, SiteKeyGuard } = require('./limits');
+const { signingSecretFromEnv } = require('./config');
 const { SuspicionLedger, computeChallengeCost, BASE_MIN_AGE_MS } = require('./suspicion');
 const { detectInputForensics } = require('./inputforensics');
 const {
@@ -36,7 +37,7 @@ app.use(express.json({ limit: MAX_REQUEST_BODY_BYTES }));
 // costs nothing on the JSON path.
 app.use(express.urlencoded({ extended: false, limit: MAX_REQUEST_BODY_BYTES }));
 
-const SECRET_KEY = process.env.FCAPTCHA_SECRET || 'dev-secret-change-in-production';
+const SECRET_KEY = signingSecretFromEnv();
 
 // The credential a backend presents to validate a token. Defaults to the signing
 // key, which is what the README has always documented, but can be separated:

--- a/server-python/config.py
+++ b/server-python/config.py
@@ -1,0 +1,23 @@
+"""Startup configuration that must fail closed in network-facing servers."""
+
+import os
+
+INSECURE_DEFAULT_SECRET = "dev-secret-change-in-production"
+
+
+def _enabled(value: str) -> bool:
+    return str(value or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def signing_secret_from_env(env=None) -> str:
+    env = os.environ if env is None else env
+    secret = str(env.get("FCAPTCHA_SECRET", "")).strip()
+    if secret and secret != INSECURE_DEFAULT_SECRET:
+        return secret
+    if _enabled(env.get("FCAPTCHA_INSECURE_DEV_MODE", "")):
+        print("WARNING: FCAPTCHA_INSECURE_DEV_MODE enabled; tokens use a public signing key. Never expose this server to a network.", flush=True)
+        return INSECURE_DEFAULT_SECRET
+    raise RuntimeError(
+        "FCAPTCHA_SECRET is required and must not be the public development key. "
+        "For local-only development, explicitly set FCAPTCHA_INSECURE_DEV_MODE=1."
+    )

--- a/server-python/server.py
+++ b/server-python/server.py
@@ -38,6 +38,7 @@ from suspicion import (
     compute_challenge_cost,
     BASE_MIN_AGE_MS,
 )
+from config import signing_secret_from_env
 
 # Keep in sync with server-node/package.json and client/fcaptcha.js on release.
 app = FastAPI(title="FCaptcha", version="1.28.2")
@@ -126,7 +127,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-SECRET_KEY = os.getenv("FCAPTCHA_SECRET", "dev-secret-change-in-production")
+SECRET_KEY = signing_secret_from_env()
 
 # The credential a backend presents to validate a token. Defaults to the signing
 # key, which is what the README has always documented, but can be separated: the

--- a/server-python/test_config.py
+++ b/server-python/test_config.py
@@ -1,0 +1,23 @@
+import unittest
+
+from config import INSECURE_DEFAULT_SECRET, signing_secret_from_env
+
+
+class SigningSecretConfigTests(unittest.TestCase):
+    def test_missing_secret_fails_closed(self):
+        with self.assertRaisesRegex(RuntimeError, "FCAPTCHA_SECRET is required"):
+            signing_secret_from_env({})
+
+    def test_public_secret_fails_closed(self):
+        with self.assertRaisesRegex(RuntimeError, "FCAPTCHA_SECRET is required"):
+            signing_secret_from_env({"FCAPTCHA_SECRET": INSECURE_DEFAULT_SECRET})
+
+    def test_configured_secret_is_returned(self):
+        self.assertEqual(signing_secret_from_env({"FCAPTCHA_SECRET": "a-real-deployment-secret"}), "a-real-deployment-secret")
+
+    def test_explicit_development_mode_allows_public_secret(self):
+        self.assertEqual(signing_secret_from_env({"FCAPTCHA_INSECURE_DEV_MODE": "1"}), INSECURE_DEFAULT_SECRET)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test.sh
+++ b/test.sh
@@ -7,6 +7,7 @@ set -e
 cd "$(dirname "$0")"
 
 SERVER=${1:-node}  # Default to node, can pass 'go' or 'python'
+export FCAPTCHA_SECRET=${FCAPTCHA_SECRET:-fcaptcha-test-suite-secret}
 
 echo "Starting $SERVER server..."
 


### PR DESCRIPTION
## Summary

- make Go, Node, and Python fail closed when FCAPTCHA_SECRET is absent or equals the public development key
- apply the same requirement to the exported Node scoring library
- provide an explicit FCAPTCHA_INSECURE_DEV_MODE escape hatch for local-only development, with a prominent warning
- make Docker Compose require secret interpolation instead of supplying a predictable fallback
- provide scoped test secrets in CI and local test tooling
- update security, installation, development, and benchmark documentation

## Compatibility

This intentionally changes unsafe zero-configuration startup. Existing deployments with FCAPTCHA_SECRET are unaffected. Local development can either set any non-public development secret or explicitly opt into FCAPTCHA_INSECURE_DEV_MODE=1.

## Validation

- full Node test suite passes
- all 84 Python tests pass
- Node startup without a secret fails
- Python import/startup without a secret fails
- Node starts normally with a configured secret
- Go configuration unit tests added; Go 1.24 CI will run them
- git diff --check passes