### PR TITLE
fix(pow): bind challenges to the issuing network

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,11 @@ If you want proof of work to genuinely raise an attacker's cost, the lever is th
 server-measured elapsed time, not the hash. That is what the adaptive cost keys
 on.
 
+The challenge is also bound to the source network that acquired that price
+(IPv4 `/24`, IPv6 `/56`). This prevents an attacker from obtaining baseline-cost
+challenges through an unrelated clean proxy and submitting them from an already
+suspicious source, while tolerating nearby address rotation on mobile networks.
+
 Each challenge carries a `minAgeMs`: how long it must be held before a solution
 is accepted without penalty. A visitor who has done nothing wrong gets the same
 1500ms floor the server has always applied. A source that has recently produced

--- a/server-go/clientip.go
+++ b/server-go/clientip.go
@@ -10,6 +10,20 @@ import (
 	"sync/atomic"
 )
 
+// NetworkIdentity returns the IPv4 /24 or IPv6 /56 containing an address.
+// This tolerates nearby mobile address rotation without making challenges
+// transferable between unrelated source networks.
+func NetworkIdentity(value string) string {
+	ip := net.ParseIP(hostOnly(value))
+	if ip == nil {
+		return ""
+	}
+	if v4 := ip.To4(); v4 != nil {
+		return v4.Mask(net.CIDRMask(24, 32)).String() + "/24"
+	}
+	return ip.Mask(net.CIDRMask(56, 128)).String() + "/56"
+}
+
 // Client IP resolution.
 //
 // Every IP-derived signal in FCaptcha — datacenter ranges, Tor/VPN, rate

--- a/server-go/networkidentity_test.go
+++ b/server-go/networkidentity_test.go
@@ -1,0 +1,18 @@
+package main
+
+import "testing"
+
+func TestNetworkIdentityUsesIPv4Slash24AndIPv6Slash56(t *testing.T) {
+	if NetworkIdentity("192.0.2.1") != NetworkIdentity("192.0.2.254") {
+		t.Fatal("addresses in one IPv4 /24 should share an identity")
+	}
+	if NetworkIdentity("192.0.2.1") == NetworkIdentity("192.0.3.1") {
+		t.Fatal("addresses in different IPv4 /24s should differ")
+	}
+	if NetworkIdentity("2001:db8:abcd:1200::1") != NetworkIdentity("2001:db8:abcd:12ff::2") {
+		t.Fatal("addresses in one IPv6 /56 should share an identity")
+	}
+	if NetworkIdentity("2001:db8:abcd:1200::1") == NetworkIdentity("2001:db8:abcd:1300::1") {
+		t.Fatal("addresses in different IPv6 /56s should differ")
+	}
+}

--- a/server-go/scoring.go
+++ b/server-go/scoring.go
@@ -375,7 +375,7 @@ func (e *ScoringEngine) VerifyWithHeaders(signals map[string]interface{}, ip, si
 	}
 	powSatisfied := false
 	if pow != nil && pow.ChallengeID != "" {
-		powResult := e.VerifyPoWSolution(pow, siteKey, pow.SignalsHash)
+		powResult := e.VerifyPoWSolutionFromIP(pow, siteKey, ip, pow.SignalsHash)
 		if !powResult.Valid {
 			detections = append(detections, DetectionResult{
 				Category:   CategoryBot,
@@ -669,6 +669,13 @@ func (e *ScoringEngine) GeneratePoWChallenge(siteKey, ip string, isDatacenter bo
 // VerifyPoWSolution verifies a PoW solution from the client
 // signalsHash is optional; if provided, it's included in the PoW input for signal binding
 func (e *ScoringEngine) VerifyPoWSolution(solution *PoWSolution, siteKey string, signalsHash ...string) PoWVerifyResult {
+	return e.VerifyPoWSolutionFromIP(solution, siteKey, "", signalsHash...)
+}
+
+// VerifyPoWSolutionFromIP additionally binds the solution to the coarse source
+// network that acquired its adaptively priced challenge. An empty IP preserves
+// the older library method's behavior; HTTP verification always supplies one.
+func (e *ScoringEngine) VerifyPoWSolutionFromIP(solution *PoWSolution, siteKey, ip string, signalsHash ...string) PoWVerifyResult {
 	if solution == nil || solution.ChallengeID == "" {
 		return PoWVerifyResult{Valid: false, Reason: "no_solution"}
 	}
@@ -689,6 +696,10 @@ func (e *ScoringEngine) VerifyPoWSolution(solution *PoWSolution, siteKey string,
 
 	if challenge.SiteKey != siteKey {
 		return PoWVerifyResult{Valid: false, Reason: "site_key_mismatch"}
+	}
+
+	if ip != "" && NetworkIdentity(challenge.IP) != NetworkIdentity(ip) {
+		return PoWVerifyResult{Valid: false, Reason: "challenge_network_mismatch"}
 	}
 
 	// Cheap early-out for obvious replays before doing hash work.

--- a/server-go/scoring_test.go
+++ b/server-go/scoring_test.go
@@ -220,6 +220,16 @@ func TestVerifyPoWSolution_ValidThenReplay(t *testing.T) {
 	}
 }
 
+func TestVerifyPoWSolutionRejectsDifferentNetwork(t *testing.T) {
+	e := NewScoringEngine("test-secret")
+	challenge := e.GeneratePoWChallenge("site-1", "203.0.113.5", false)
+	solution := solvePoW(t, challenge)
+	result := e.VerifyPoWSolutionFromIP(solution, "site-1", "198.51.100.5")
+	if result.Valid || result.Reason != "challenge_network_mismatch" {
+		t.Fatalf("got valid=%v reason=%q", result.Valid, result.Reason)
+	}
+}
+
 // TestCheckDeclaredAIAgent verifies self-identifying AI agents are flagged under
 // the declared_ai category and that ordinary browsers are not. Web Bot Auth
 // signature handling moved to CheckWebBotAuth; see TestWebBotAuth* below.

--- a/server-node/clientip.js
+++ b/server-node/clientip.js
@@ -61,6 +61,18 @@ function normalizeIP(value) {
   }
 }
 
+// Bind challenges to a coarse source network: tolerant of nearby mobile address
+// rotation, but not transferable from an unrelated clean proxy.
+function networkIdentity(value) {
+  const normalized = normalizeIP(value);
+  if (!normalized) return '';
+  let addr = ipaddr.parse(normalized);
+  if (addr.kind() === 'ipv6' && addr.isIPv4MappedAddress()) addr = addr.toIPv4Address();
+  const bytes = addr.toByteArray();
+  if (addr.kind() === 'ipv4') return `4:${bytes.slice(0, 3).join('.')}`;
+  return `6:${bytes.slice(0, 7).map((b) => b.toString(16).padStart(2, '0')).join('')}`;
+}
+
 // Node merges repeated headers into one comma-joined string for everything
 // except set-cookie, but accept an array defensively.
 function headerValue(req, name) {
@@ -225,5 +237,6 @@ class ProxyTrust {
 module.exports = {
   ProxyTrust,
   DEFAULT_TRUSTED_PROXY_CIDRS,
-  normalizeIP
+  normalizeIP,
+  networkIdentity
 };

--- a/server-node/clientip.test.js
+++ b/server-node/clientip.test.js
@@ -5,7 +5,7 @@
  */
 
 const assert = require('assert');
-const { ProxyTrust } = require('./clientip');
+const { ProxyTrust, networkIdentity } = require('./clientip');
 
 const DEFAULT_SPEC = '127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16';
 
@@ -18,6 +18,13 @@ function request(remoteAddress, headers = {}) {
 
 const tests = [];
 const test = (name, fn) => tests.push({ name, fn });
+
+test('challenge network identity uses IPv4 /24 and IPv6 /56', () => {
+  assert.strictEqual(networkIdentity('192.0.2.1'), networkIdentity('192.0.2.254'));
+  assert.notStrictEqual(networkIdentity('192.0.2.1'), networkIdentity('192.0.3.1'));
+  assert.strictEqual(networkIdentity('2001:db8:abcd:1200::1'), networkIdentity('2001:db8:abcd:12ff::2'));
+  assert.notStrictEqual(networkIdentity('2001:db8:abcd:1200::1'), networkIdentity('2001:db8:abcd:1300::1'));
+});
 
 // The bypass this file exists to prevent: a caller reaching the server directly
 // claims a residential IP and expects the datacenter/Tor/rate-limit checks to

--- a/server-node/index.js
+++ b/server-node/index.js
@@ -11,7 +11,7 @@
 
 const crypto = require('crypto');
 const detection = require('./detection');
-const { ProxyTrust } = require('./clientip');
+const { ProxyTrust, networkIdentity } = require('./clientip');
 const { SuspicionLedger, computeChallengeCost, BASE_MIN_AGE_MS } = require('./suspicion');
 const { signingSecret } = require('./config');
 
@@ -64,7 +64,7 @@ class PoWChallengeStore {
     return challengeData;
   }
 
-  verify(challengeId, nonce, hash, siteKey) {
+  verify(challengeId, nonce, hash, siteKey, ip) {
     const challenge = this.challenges.get(challengeId);
 
     if (!challenge) {
@@ -78,6 +78,10 @@ class PoWChallengeStore {
 
     if (challenge.siteKey !== siteKey) {
       return { valid: false, reason: 'site_key_mismatch' };
+    }
+
+    if (networkIdentity(challenge.ip) !== networkIdentity(ip)) {
+      return { valid: false, reason: 'challenge_network_mismatch' };
     }
 
     // Check for replay
@@ -263,7 +267,8 @@ class ScoringEngine {
         powSolution.challengeId,
         powSolution.nonce,
         powSolution.hash,
-        siteKey
+        siteKey,
+        ip
       );
 
       if (!powResult.valid) {

--- a/server-node/index.test.js
+++ b/server-node/index.test.js
@@ -64,4 +64,18 @@ const cleanHeaders = {
   assert.ok(result.token, 'valid PoW may mint a token');
 }
 
+{
+  const engine = createScoringEngine({ secret: 'test-secret' });
+  const challenge = engine.generateChallenge('site', '203.0.113.1', {
+    difficulty: 1,
+    scaleByReputation: false
+  });
+  const result = engine.verify(
+    cleanSignals, '198.51.100.1', 'site', 'Mozilla/5.0', cleanHeaders, solve(challenge)
+  );
+  assert.strictEqual(result.success, false, 'a different network must not spend the challenge');
+  assert.strictEqual(result.reason, 'pow_not_satisfied');
+  assert.ok(result.detections.some((d) => d.reason.includes('challenge_network_mismatch')));
+}
+
 console.log('index.js security gate tests passed');

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -10,7 +10,7 @@ const crypto = require('crypto');
 const path = require('path');
 const detection = require('./detection');
 const webbotauth = require('./webbotauth');
-const { ProxyTrust } = require('./clientip');
+const { ProxyTrust, networkIdentity } = require('./clientip');
 const { BoundedMap, BoundedSet, SiteKeyGuard } = require('./limits');
 const { signingSecretFromEnv } = require('./config');
 const { SuspicionLedger, computeChallengeCost, BASE_MIN_AGE_MS } = require('./suspicion');
@@ -182,7 +182,7 @@ const powChallengeStore = {
   },
 
   // Verify a PoW solution (signalsHash is optional for backward compat)
-  verify(challengeId, nonce, hash, siteKey, signalsHash = null) {
+  verify(challengeId, nonce, hash, siteKey, ip, signalsHash = null) {
     const challenge = this.challenges.get(challengeId);
 
     if (!challenge) {
@@ -196,6 +196,10 @@ const powChallengeStore = {
 
     if (challenge.siteKey !== siteKey) {
       return { valid: false, reason: 'site_key_mismatch' };
+    }
+
+    if (networkIdentity(challenge.ip) !== networkIdentity(ip)) {
+      return { valid: false, reason: 'challenge_network_mismatch' };
     }
 
     // Check if solution was already used (prevent replay)
@@ -1420,6 +1424,7 @@ function runVerification(signals, ip, siteKey, userAgent, headers = {}, ja3Hash 
       powSolution.nonce,
       powSolution.hash,
       siteKey,
+      ip,
       clientSignalsHash
     );
     powValid = powVerification.valid;

--- a/server-python/clientip.py
+++ b/server-python/clientip.py
@@ -72,6 +72,15 @@ def normalize_ip(value: Optional[str]) -> Optional[str]:
     return str(addr) if addr is not None else None
 
 
+def network_identity(value: Optional[str]) -> str:
+    """Return the IPv4 /24 or IPv6 /56 containing an address."""
+    addr = _parse_ip(value)
+    if addr is None:
+        return ""
+    prefix = 24 if isinstance(addr, ipaddress.IPv4Address) else 56
+    return str(ipaddress.ip_network(f"{addr}/{prefix}", strict=False))
+
+
 # Bounds the misconfiguration hint below. A directly exposed server sees spoof
 # attempts continuously, and that is working as intended - the operator needs the
 # hint once, not a running commentary.

--- a/server-python/server.py
+++ b/server-python/server.py
@@ -21,7 +21,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel
 
-from clientip import ProxyTrust
+from clientip import ProxyTrust, network_identity
 from sitekeys import SiteKeyGuard
 from siteverify import (
     HostnameAllowlist,
@@ -411,7 +411,7 @@ class PoWChallengeStore:
             "minAgeMs": min_age_ms
         }
 
-    def verify(self, solution: PoWSolution, site_key: str, signals_hash: str = None) -> Dict:
+    def verify(self, solution: PoWSolution, site_key: str, ip: str, signals_hash: str = None) -> Dict:
         if not solution or not solution.challengeId:
             return {"valid": False, "reason": "no_solution"}
 
@@ -426,6 +426,9 @@ class PoWChallengeStore:
 
         if challenge["siteKey"] != site_key:
             return {"valid": False, "reason": "site_key_mismatch"}
+
+        if network_identity(challenge["ip"]) != network_identity(ip):
+            return {"valid": False, "reason": "challenge_network_mismatch"}
 
         # Check if solution was already used
         solution_key = f"{solution.challengeId}:{solution.nonce}"
@@ -1604,7 +1607,7 @@ def run_verification(
     # correct; the aggregation discarded them.
     pow_satisfied = False
     if pow_solution:
-        pow_result = pow_store.verify(pow_solution, site_key, client_signals_hash)
+        pow_result = pow_store.verify(pow_solution, site_key, ip, client_signals_hash)
         if not pow_result["valid"]:
             detections.append(Detection(
                 ThreatCategory.BOT, 0.7, 0.8,

--- a/server-python/test_clientip.py
+++ b/server-python/test_clientip.py
@@ -6,9 +6,19 @@ Run: python3 test_clientip.py
 
 from testkit import TestRegistry
 
-from clientip import MAX_PROXY_MISCONFIG_WARNINGS, ProxyTrust
+from clientip import MAX_PROXY_MISCONFIG_WARNINGS, ProxyTrust, network_identity
 
 DEFAULT_SPEC = "127.0.0.0/8,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+
+test = TestRegistry()
+
+
+@test
+def challenge_network_identity_uses_v4_24_and_v6_56():
+    assert network_identity("192.0.2.1") == network_identity("192.0.2.254")
+    assert network_identity("192.0.2.1") != network_identity("192.0.3.1")
+    assert network_identity("2001:db8:abcd:1200::1") == network_identity("2001:db8:abcd:12ff::2")
+    assert network_identity("2001:db8:abcd:1200::1") != network_identity("2001:db8:abcd:1300::1")
 
 
 class _Headers(dict):
@@ -29,10 +39,6 @@ class FakeRequest:
     def __init__(self, host, headers=None):
         self.client = _Client(host) if host is not None else None
         self.headers = _Headers({k.lower(): v for k, v in (headers or {}).items()})
-
-
-test = TestRegistry()
-
 
 @test
 def headers_from_untrusted_peer_are_ignored():

--- a/test/test-detection.js
+++ b/test/test-detection.js
@@ -104,6 +104,30 @@ async function testRequestBodyLimit() {
   }
 }
 
+async function testChallengeNetworkBinding() {
+  log('Challenge network binding:', colors.cyan);
+  const { body } = await buildVerifyBody(
+    SERVER_URL,
+    'network-binding-test',
+    {},
+    { 'X-Real-IP': '203.0.113.10' }
+  );
+  const result = await makeRequest('/api/verify', {
+    headers: { 'X-Real-IP': '198.51.100.10' },
+    body,
+  });
+  const mismatch = (result.detections || []).some(
+    (d) => d.reason && d.reason.includes('challenge_network_mismatch')
+  );
+  if (!result.success && !result.token && mismatch) {
+    passed++;
+    log('  ✓ Challenge cannot be transferred to another network', colors.green);
+  } else {
+    failed++;
+    log('  ✗ Challenge transfer was not rejected', colors.red);
+  }
+}
+
 function assertDetection(result, category, shouldDetect, testName) {
   const detections = result.detections || [];
   const hasCategory = detections.some(d => d.category === category);
@@ -2688,6 +2712,7 @@ async function runTests() {
   await testTokenVerification();
   await testInvisibleMode();
   await testRequestBodyLimit();
+  await testChallengeNetworkBinding();
 
   // Summary
   log(`\n${colors.bold}═══════════════════════════════════════${colors.reset}`);


### PR DESCRIPTION
## Summary

- bind PoW challenges to the coarse network that acquired them
- use IPv4 /24 and IPv6 /56 identities to tolerate nearby mobile address rotation
- reject cross-network transfers before consuming the challenge
- enforce the rule in Go, Node, Python, and the exported Node engine
- add unit and shared end-to-end regression coverage

## Why

Adaptive challenge cost is keyed to source reputation, but the stored issuing IP was never checked during verification. An attacker could acquire a baseline-cost challenge through an unrelated clean proxy and submit it from an already suspicious source.

## Compatibility

Exact-address binding would create avoidable failures for mobile users. The coarse network policy admits ordinary nearby rotation while preventing transfer across unrelated networks.

## Validation

- full Node unit suite passes
- all 81 Python tests pass
- live end-to-end detection suite passes all 111 checks
- Go unit coverage added; Go 1.24 CI will execute it
- git diff --check passes