### PR TITLE
fix(verify): separate backend and visitor IPs

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -600,6 +600,10 @@ changes. If it does not, either add it:
 or set `FCAPTCHA_LEGACY_UNAUTH_VERIFY=true` to keep the old behaviour for one
 release while you update. A wrong or missing secret answers `401`.
 
+The native endpoint also accepts an optional `remoteip` containing the original
+visitor address. Omit it to skip IP binding. FCaptcha does not use the backend
+caller's socket address because that is not the visitor who received the token.
+
 **2. The token format is now identical across the three servers.**
 
 Go emitted padded base64url, Node unpadded, and Python signed a payload with

--- a/README.md
+++ b/README.md
@@ -664,11 +664,17 @@ meant anyone who could reach the endpoint could spend a token — set
 `FCAPTCHA_LEGACY_UNAUTH_VERIFY=true` for one release if you need the old
 behaviour while you update your backend.
 
+`remoteip` is optional. When supplied, it must be the visitor IP associated with
+the original browser request and is checked against the token. When omitted, no
+IP check is performed. The API never uses the verification caller's socket
+address for this check because that caller is normally your backend server.
+
 ```json
 // Request
 {
   "token": "...",
-  "secret": "your-secret"
+  "secret": "your-secret",
+  "remoteip": "203.0.113.10"
 }
 
 // Response

--- a/server-go/main.go
+++ b/server-go/main.go
@@ -690,8 +690,9 @@ func invisibleScoreHandler(engine *ScoringEngine, trust *ProxyTrust, siteKeys *S
 
 // TokenVerifyRequest for server-side token verification
 type TokenVerifyRequest struct {
-	Token  string `json:"token"`
-	Secret string `json:"secret"`
+	Token    string `json:"token"`
+	Secret   string `json:"secret"`
+	RemoteIP string `json:"remoteip,omitempty"`
 }
 
 func tokenVerifyHandler(engine *ScoringEngine, trust *ProxyTrust, verifySecret string, requireSecret bool) http.HandlerFunc {
@@ -721,10 +722,9 @@ func tokenVerifyHandler(engine *ScoringEngine, trust *ProxyTrust, verifySecret s
 			}
 		}
 
-		// Extract client IP for verification
-		ip := trust.ClientIP(r)
-
-		result := engine.VerifyTokenWithIP(req.Token, ip)
+		// The caller is the integrating backend, not the visitor who received
+		// the token. Bind only to an explicitly supplied visitor address.
+		result := engine.VerifyTokenWithIP(req.Token, req.RemoteIP)
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(result)

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -1704,7 +1704,7 @@ app.post('/api/score', async (req, res) => {
 });
 
 app.post('/api/token/verify', (req, res) => {
-  const { token, secret } = req.body;
+  const { token, secret, remoteip } = req.body;
 
   // The secret gate. This endpoint is the boundary between "a browser finished a
   // challenge" and "my backend believes it", so it is server-to-server and needs
@@ -1719,10 +1719,10 @@ app.post('/api/token/verify', (req, res) => {
     }
   }
 
-  // Extract client IP for verification
-  const ip = PROXY_TRUST.clientIP(req);
-
-  res.json(verifyToken(token, ip));
+  // This request comes from the integrating backend, not from the visitor who
+  // received the token. Bind only when that trusted backend explicitly supplies
+  // the visitor address; using the caller socket here compares unrelated hosts.
+  res.json(verifyToken(token, typeof remoteip === 'string' && remoteip ? remoteip : null));
 });
 
 // Turnstile / reCAPTCHA / hCaptcha drop-in compatibility.

--- a/server-python/server.py
+++ b/server-python/server.py
@@ -264,6 +264,7 @@ class TokenVerifyRequest(BaseModel):
     token: str
     # Declared but never checked until now: see the token_verify handler.
     secret: str = ""
+    remoteip: Optional[str] = None
 
 
 # =============================================================================
@@ -1898,9 +1899,9 @@ async def token_verify(req: TokenVerifyRequest, request: Request):
                 status_code=401, content={"valid": False, "reason": "invalid_secret"}
             )
 
-    # Extract client IP for verification
-    ip = PROXY_TRUST.client_ip(request)
-    return verify_token(req.token, ip)
+    # The caller is the integrating backend, not the visitor who received the
+    # token. Bind only to an explicitly supplied visitor address.
+    return verify_token(req.token, req.remoteip)
 
 
 # Turnstile / reCAPTCHA / hCaptcha drop-in compatibility.

--- a/test/test-detection.js
+++ b/test/test-detection.js
@@ -504,6 +504,7 @@ async function testBehavioralSignals() {
       'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0',
       'Accept-Language': 'en-US,en;q=0.9',
       'Accept-Encoding': 'gzip, deflate, br',
+      'X-Real-IP': '203.0.113.10',
     },
     body: {
       siteKey: 'test',
@@ -1088,13 +1089,36 @@ async function testTokenVerification() {
 
     if (tokenResult.valid) {
       passed++;
-      log(`  ✓ Token verification works (score: ${tokenResult.score})`, colors.green);
+      log(`  ✓ Backend can verify without binding to its own socket IP (score: ${tokenResult.score})`, colors.green);
     } else {
       failed++;
       log(`  ✗ Token verification failed: ${tokenResult.reason}`, colors.red);
     }
   } else {
     log(`  - Skipped: No token generated (score too high: ${verifyResult.score})`, colors.yellow);
+  }
+
+  // Explicit remoteip remains available when an integration wants binding.
+  const boundResult = await makeVerifiedRequest({
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0',
+      'Accept-Language': 'en-US,en;q=0.9',
+      'Accept-Encoding': 'gzip, deflate, br',
+      'X-Real-IP': '203.0.113.20',
+    },
+    body: { siteKey: 'token-ip-binding', signals: { behavioral: { totalPoints: 80 } } }
+  });
+  if (boundResult.token) {
+    const mismatch = await makeRequest('/api/token/verify', {
+      body: { token: boundResult.token, secret: VERIFY_SECRET, remoteip: '198.51.100.20' }
+    });
+    if (!mismatch.valid && mismatch.reason === 'ip_mismatch') {
+      passed++;
+      log('  ✓ Explicit visitor remoteip mismatch is rejected', colors.green);
+    } else {
+      failed++;
+      log(`  ✗ Explicit remoteip mismatch was accepted: ${JSON.stringify(mismatch)}`, colors.red);
+    }
   }
 
   // Test invalid token


### PR DESCRIPTION
## Summary

- stop binding native token verification to the backend caller socket
- accept optional remoteip as the original visitor address
- omit remoteip to verify without IP binding, matching Siteverify semantics
- document the contract across API and installation guidance
- add end-to-end regression coverage for backend/visitor separation and explicit mismatch rejection

## Why

Tokens are minted for browser visitors, while POST /api/token/verify is called by an integrating backend. Comparing those two socket addresses rejects legitimate production requests whenever the backend and visitor are different hosts.

## Validation

- Node unit suite passes
- all 87 Python tests pass
- live end-to-end suite passes all 112 checks
- explicit wrong remoteip returns ip_mismatch
- omitted remoteip verifies from a different backend socket
- Go CI will run the handler build and suite