### PR TITLE
feat(node): share proof-of-work state through Redis

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -274,7 +274,8 @@ FCaptcha state is process-local by default. In the Go server, `REDIS_URL` now
 shares PoW challenges, token replay protection, Siteverify idempotency, rate
 limits, suspicion, fingerprint cardinality, and site-key rotation guards.
 Challenge and token claims are atomic. Go may run multiple replicas when Redis
-is configured; Node and Python must remain single-instance.
+is configured. Node currently shares only PoW challenge/claim state, and Python
+does not yet use Redis; both must remain single-instance.
 
 Run:
 
@@ -424,8 +425,9 @@ server {
 ```
 
 **Important:** Multiple Go instances require `REDIS_URL`; without it, all state
-is process-local. Node and Python remain entirely process-local and must run as
-one instance.
+is process-local. Node shares only PoW state when Redis is configured; its other
+stores remain local. Python remains entirely process-local. Both must run as one
+instance.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ rotation guards across replicas. Challenge and token consumption are atomic.
 It refuses to start if configured Redis is unavailable and fails closed if it
 becomes unavailable later.
 
-With `REDIS_URL`, the Go server can run multiple replicas. Node and Python do
-not yet use Redis and must remain single-instance.
+With `REDIS_URL`, the Go server can run multiple replicas. Node currently shares
+PoW challenge/claim state only; its other stores remain local, so it must remain
+single-instance. Python does not yet use Redis and must also remain
+single-instance.
 
 Kubernetes:
 

--- a/server-node/package.json
+++ b/server-node/package.json
@@ -15,7 +15,7 @@
     "test:clientip": "node clientip.test.js",
     "test:limits": "node limits.test.js",
     "test:detection": "node detection.test.js",
-    "test": "node version.test.js && node config.test.js && node clientip.test.js && node limits.test.js && node detection.test.js && node inputforensics.test.js && node interactionmode.test.js && node exemptions.test.js && node webbotauth.test.js && node siteverify.test.js && node index.test.js && node --test suspicion.test.js",
+    "test": "node version.test.js && node config.test.js && node clientip.test.js && node limits.test.js && node detection.test.js && node inputforensics.test.js && node interactionmode.test.js && node exemptions.test.js && node webbotauth.test.js && node siteverify.test.js && node redis-state.test.js && node index.test.js && node --test suspicion.test.js",
     "test:siteverify": "node siteverify.test.js",
     "test:forensics": "node inputforensics.test.js",
     "test:suspicion": "node --test suspicion.test.js"

--- a/server-node/redis-state.js
+++ b/server-node/redis-state.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const { createClient } = require('redis');
+
+const PREFIX = 'fcaptcha:v1:';
+const POW_TTL_MS = 5 * 60 * 1000;
+const SPENT_TTL_MS = 10 * 60 * 1000;
+
+const CLAIM_CHALLENGE = `
+if redis.call('EXISTS', KEYS[1]) == 0 then return 0 end
+if redis.call('SET', KEYS[2], '1', 'NX', 'PX', ARGV[1]) == false then return -1 end
+redis.call('DEL', KEYS[1])
+return 1
+`;
+
+class RedisState {
+  constructor(url, client = null) {
+    this.client = client || createClient({ url });
+    this.client.on?.('error', (err) => console.error('[redis]', err.message));
+  }
+
+  async connect() {
+    if (!this.client.isOpen) await this.client.connect();
+    await this.client.ping();
+  }
+
+  challengeKey(id) {
+    return `${PREFIX}pow:challenge:${id}`;
+  }
+
+  async putChallenge(challenge) {
+    const ttl = challenge.expiresAt - Date.now();
+    if (ttl <= 0) throw new Error('challenge already expired');
+    // challengeId is the canonical cross-runtime field used by Go and Node.
+    const stored = { ...challenge, challengeId: challenge.id };
+    delete stored.id;
+    await this.client.set(this.challengeKey(challenge.id), JSON.stringify(stored), { PX: ttl });
+  }
+
+  async getChallenge(id) {
+    const payload = await this.client.get(this.challengeKey(id));
+    if (!payload) return null;
+    const challenge = JSON.parse(payload);
+    return { ...challenge, id: challenge.challengeId };
+  }
+
+  async claimChallenge(challengeId, solutionKey) {
+    const result = Number(await this.client.eval(CLAIM_CHALLENGE, {
+      keys: [this.challengeKey(challengeId), `${PREFIX}pow:spent:${solutionKey}`],
+      arguments: [String(SPENT_TTL_MS)]
+    }));
+    if (result === 1) return { claimed: true };
+    return {
+      claimed: false,
+      reason: result === -1 ? 'solution_already_used' : 'challenge_not_found'
+    };
+  }
+}
+
+module.exports = { RedisState, PREFIX, POW_TTL_MS, SPENT_TTL_MS };

--- a/server-node/redis-state.test.js
+++ b/server-node/redis-state.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const assert = require('assert');
+const { RedisState } = require('./redis-state');
+
+class FakeRedis {
+  constructor() {
+    this.isOpen = true;
+    this.values = new Map();
+  }
+  on() {}
+  async ping() { return 'PONG'; }
+  async set(key, value) { this.values.set(key, value); return 'OK'; }
+  async get(key) { return this.values.get(key) || null; }
+  async eval(_script, { keys }) {
+    if (!this.values.has(keys[0])) return 0;
+    if (this.values.has(keys[1])) return -1;
+    this.values.set(keys[1], '1');
+    this.values.delete(keys[0]);
+    return 1;
+  }
+}
+
+(async () => {
+  const fake = new FakeRedis();
+  const issuer = new RedisState('redis://unused', fake);
+  const verifier = new RedisState('redis://unused', fake);
+  const challenge = {
+    id: 'challenge-1', siteKey: 'site', timestamp: Date.now(),
+    expiresAt: Date.now() + 60_000, difficulty: 4, prefix: 'prefix',
+    minAgeMs: 1500, nonce: 'binding', sig: 'signature', ip: '203.0.113.5'
+  };
+
+  await issuer.putChallenge(challenge);
+  const loaded = await verifier.getChallenge(challenge.id);
+  assert.strictEqual(loaded.id, challenge.id);
+  assert.strictEqual(loaded.ip, challenge.ip);
+  assert.strictEqual(JSON.parse(fake.values.values().next().value).challengeId, challenge.id);
+
+  assert.deepStrictEqual(await verifier.claimChallenge(challenge.id, 'challenge-1:7'), { claimed: true });
+  assert.deepStrictEqual(
+    await issuer.claimChallenge(challenge.id, 'challenge-1:7'),
+    { claimed: false, reason: 'challenge_not_found' }
+  );
+  console.log('redis shared-state tests passed');
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -15,6 +15,7 @@ const { BoundedMap, BoundedSet, SiteKeyGuard } = require('./limits');
 const { signingSecretFromEnv } = require('./config');
 const { SuspicionLedger, computeChallengeCost, BASE_MIN_AGE_MS } = require('./suspicion');
 const { detectInputForensics } = require('./inputforensics');
+const { RedisState } = require('./redis-state');
 const {
   HostnameAllowlist,
   IdempotencyStore,
@@ -37,6 +38,8 @@ app.use(express.json({ limit: MAX_REQUEST_BODY_BYTES }));
 app.use(express.urlencoded({ extended: false, limit: MAX_REQUEST_BODY_BYTES }));
 
 const SECRET_KEY = signingSecretFromEnv();
+const REDIS_URL = process.env.REDIS_URL || '';
+const SHARED_STATE = REDIS_URL ? new RedisState(REDIS_URL) : null;
 
 // The credential a backend presents to validate a token. Defaults to the signing
 // key, which is what the README has always documented, but can be separated:
@@ -142,7 +145,7 @@ const powChallengeStore = {
   usedSolutions: new BoundedSet(),
 
   // Generate a new challenge
-  generate(siteKey, ip, difficulty = 4, minAgeMs = BASE_MIN_AGE_MS) {
+  async generate(siteKey, ip, difficulty = 4, minAgeMs = BASE_MIN_AGE_MS) {
     const challengeId = crypto.randomBytes(16).toString('hex');
     const nonce = crypto.randomBytes(16).toString('hex');
     const timestamp = Date.now();
@@ -167,12 +170,16 @@ const powChallengeStore = {
       .update(JSON.stringify(challengeData))
       .digest('hex');
 
-    // Store challenge
-    this.challenges.set(challengeId, {
+    const storedChallenge = {
       ...challengeData,
       ip,
       createdAt: timestamp
-    });
+    };
+    if (SHARED_STATE) {
+      await SHARED_STATE.putChallenge(storedChallenge);
+    } else {
+      this.challenges.set(challengeId, storedChallenge);
+    }
 
     // Cleanup old challenges periodically
     if (Math.random() < 0.1) this._cleanup();
@@ -181,15 +188,22 @@ const powChallengeStore = {
   },
 
   // Verify a PoW solution (signalsHash is optional for backward compat)
-  verify(challengeId, nonce, hash, siteKey, ip, signalsHash = null) {
-    const challenge = this.challenges.get(challengeId);
+  async verify(challengeId, nonce, hash, siteKey, ip, signalsHash = null) {
+    let challenge;
+    try {
+      challenge = SHARED_STATE
+        ? await SHARED_STATE.getChallenge(challengeId)
+        : this.challenges.get(challengeId);
+    } catch (_) {
+      return { valid: false, reason: 'state_unavailable' };
+    }
 
     if (!challenge) {
       return { valid: false, reason: 'challenge_not_found' };
     }
 
     if (Date.now() > challenge.expiresAt) {
-      this.challenges.delete(challengeId);
+      if (!SHARED_STATE) this.challenges.delete(challengeId);
       return { valid: false, reason: 'challenge_expired' };
     }
 
@@ -223,11 +237,22 @@ const powChallengeStore = {
       return { valid: false, reason: 'insufficient_difficulty' };
     }
 
-    // Mark solution as used
-    this.usedSolutions.add(solutionKey);
-
-    // Delete challenge (one-time use)
-    this.challenges.delete(challengeId);
+    if (SHARED_STATE) {
+      try {
+        const claim = await SHARED_STATE.claimChallenge(challengeId, solutionKey);
+        if (!claim.claimed) return { valid: false, reason: claim.reason };
+      } catch (_) {
+        return { valid: false, reason: 'state_unavailable' };
+      }
+    } else {
+      // The local store is synchronous, so this test-and-set is atomic within
+      // one event-loop turn.
+      if (this.usedSolutions.has(solutionKey)) {
+        return { valid: false, reason: 'solution_already_used' };
+      }
+      this.usedSolutions.add(solutionKey);
+      this.challenges.delete(challengeId);
+    }
 
     // Calculate server-side elapsed time (un-spoofable)
     const serverElapsed = Date.now() - challenge.createdAt;
@@ -516,7 +541,7 @@ async function verifyWebBotAuth(req) {
 // require the raw request — currently Web Bot Auth signature verification, which
 // needs the accurately-reconstructed signed request. They are seeded into the
 // detection set so they participate in scoring like any other detection.
-function runVerification(signals, ip, siteKey, userAgent, headers = {}, ja3Hash = null, powSolution = null, signalsJson = null, powTiming = null, preDetections = [], opts = {}) {
+async function runVerification(signals, ip, siteKey, userAgent, headers = {}, ja3Hash = null, powSolution = null, signalsJson = null, powTiming = null, preDetections = [], opts = {}) {
   const detections = Array.isArray(preDetections) ? [...preDetections] : [];
 
   // Verify signal commitment (signalsJson hash must match powSolution.signalsHash)
@@ -567,7 +592,7 @@ function runVerification(signals, ip, siteKey, userAgent, headers = {}, ja3Hash 
   let powSatisfied = false;
   let powVerification = null;
   if (powSolution && powSolution.challengeId) {
-    powVerification = powChallengeStore.verify(
+    powVerification = await powChallengeStore.verify(
       powSolution.challengeId,
       powSolution.nonce,
       powSolution.hash,
@@ -818,7 +843,7 @@ app.post('/api/verify', async (req, res) => {
   // Web Bot Auth verification needs the raw request; its verdict is scored.
   const webBotAuth = await verifyWebBotAuth(req);
 
-  const result = runVerification(signals, ip, siteKey, userAgent, headers, ja3Hash, powSolution, signalsJson, powTiming, webBotAuth, { peerTrusted, action, cdata, widgetInteraction: true });
+  const result = await runVerification(signals, ip, siteKey, userAgent, headers, ja3Hash, powSolution, signalsJson, powTiming, webBotAuth, { peerTrusted, action, cdata, widgetInteraction: true });
   logVerdict('verify', siteKey, result);
   res.json(result);
 });
@@ -840,7 +865,7 @@ app.post('/api/score', async (req, res) => {
   const webBotAuth = await verifyWebBotAuth(req);
 
   // Invisible scoring: no widget, so no click analysis in the signals.
-  const result = runVerification(signals, ip, siteKey, userAgent, headers, ja3Hash, powSolution, signalsJson, powTiming, webBotAuth, { peerTrusted, action, cdata, widgetInteraction: false });
+  const result = await runVerification(signals, ip, siteKey, userAgent, headers, ja3Hash, powSolution, signalsJson, powTiming, webBotAuth, { peerTrusted, action, cdata, widgetInteraction: false });
   logVerdict('score', siteKey, result);
   res.json({
     success: result.success,
@@ -904,7 +929,7 @@ app.post('/recaptcha/api/siteverify', siteverifyHandler);
 app.post('/siteverify', siteverifyHandler);
 
 // PoW Challenge endpoint - client fetches this on page load
-app.get('/api/pow/challenge', (req, res) => {
+app.get('/api/pow/challenge', async (req, res) => {
   const ip = PROXY_TRUST.clientIP(req);
   const siteKey = SITE_KEYS.normalize(req.query.siteKey, ip);
 
@@ -919,7 +944,12 @@ app.get('/api/pow/challenge', (req, res) => {
     exceeded
   );
 
-  const challenge = powChallengeStore.generate(siteKey, ip, cost.difficulty, cost.minAgeMs);
+  let challenge;
+  try {
+    challenge = await powChallengeStore.generate(siteKey, ip, cost.difficulty, cost.minAgeMs);
+  } catch (_) {
+    return res.status(503).json({ error: 'state_unavailable' });
+  }
 
   res.json({
     challengeId: challenge.id,
@@ -959,8 +989,17 @@ app.use((err, req, res, next) => {
 // Start
 // =============================================================================
 
-app.listen(PORT, () => {
-  console.log(`FCaptcha server running on port ${PORT}`);
-  console.log(`Trusted proxies: ${PROXY_TRUST.describe()}`);
-  console.log(`Site keys: ${SITE_KEYS.describe()}`);
+async function start() {
+  if (SHARED_STATE) await SHARED_STATE.connect();
+  app.listen(PORT, () => {
+    console.log(`FCaptcha server running on port ${PORT}`);
+    console.log(`Trusted proxies: ${PROXY_TRUST.describe()}`);
+    console.log(`Site keys: ${SITE_KEYS.describe()}`);
+    console.log(`Shared state: ${SHARED_STATE ? 'Redis (PoW)' : 'in-memory'}`);
+  });
+}
+
+start().catch((err) => {
+  console.error(`FCaptcha failed to start: ${err.message}`);
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary
- persist Node PoW challenges in the same Redis schema as Go
- atomically consume challenges across replicas
- fail startup closed when configured Redis is unavailable and return state_unavailable on runtime read/claim failures
- preserve the in-memory default
- add Redis adapter unit coverage and update README/installation capability notes

## Stack
Depends on #43. Retarget to main after #43 merges.

## Validation
- npm test
- live Node server: 12/12 cross-server conformance checks