### PR TITLE
Fix verification bypasses, bound state, and clean up browser sessions

### DIFF
--- a/.github/workflows/redis-conformance.yml
+++ b/.github/workflows/redis-conformance.yml
@@ -19,6 +19,15 @@ jobs:
             dockerfile: server-node/Dockerfile
           - implementation: python
             dockerfile: server-python/Dockerfile
+          - implementation: go-node
+            dockerfile: docker/Dockerfile
+            peerDockerfile: server-node/Dockerfile
+          - implementation: node-python
+            dockerfile: server-node/Dockerfile
+            peerDockerfile: server-python/Dockerfile
+          - implementation: python-go
+            dockerfile: server-python/Dockerfile
+            peerDockerfile: docker/Dockerfile
     services:
       redis:
         image: redis:7-alpine
@@ -35,12 +44,19 @@ jobs:
           node-version: '20'
       - name: Build production image
         run: docker build -f ${{ matrix.dockerfile }} -t fcaptcha-redis-test .
+      - name: Build peer image
+        run: |
+          if [ -n "${{ matrix.peerDockerfile }}" ]; then
+            docker build -f "${{ matrix.peerDockerfile }}" -t fcaptcha-redis-peer .
+          else
+            docker tag fcaptcha-redis-test fcaptcha-redis-peer
+          fi
       - name: Start two replicas
         env:
           FCAPTCHA_SECRET: redis-conformance-secret
         run: |
           docker run -d --name fcaptcha-a --network host -e PORT=3101 -e REDIS_URL=redis://127.0.0.1:6379 -e FCAPTCHA_SECRET="$FCAPTCHA_SECRET" fcaptcha-redis-test
-          docker run -d --name fcaptcha-b --network host -e PORT=3102 -e REDIS_URL=redis://127.0.0.1:6379 -e FCAPTCHA_SECRET="$FCAPTCHA_SECRET" fcaptcha-redis-test
+          docker run -d --name fcaptcha-b --network host -e PORT=3102 -e REDIS_URL=redis://127.0.0.1:6379 -e FCAPTCHA_SECRET="$FCAPTCHA_SECRET" fcaptcha-redis-peer
           for port in 3101 3102; do
             for attempt in $(seq 1 30); do
               curl -fsS "http://127.0.0.1:$port/health" && break

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,33 @@ the project uses [Semantic Versioning](https://semver.org/) — with the caveat
 that pre-2.0 it has used minor bumps for behaviour changes that a stricter
 reading would call major. Read the **Breaking** entries rather than the number.
 
+## [Unreleased]
+
+### Security and fixes
+- Reject mismatched signal commitments and unmet challenge minimum ages outside
+  the weighted score. Go consumes a verified proof even when its signal
+  commitment fails, matching Node and Python.
+- Require the server-issued challenge nonce in npm engine signals, including
+  proofs without `signalsHash`. Missing or incorrect nonces withhold tokens and
+  produce the same diagnostic as the standalone server.
+- Prevent Node request errors from terminating the server. Request validation
+  applies only to scoring POST routes; other methods retain normal routing.
+- Make issued tokens unique and npm verification single-use. A full local Node
+  replay store reports `token_store_full` (Siteverify: `internal-error`) instead
+  of reporting an unused token as a replay.
+- Fix expired and consumed challenge reuse and clean up browser session resources.
+
+### Behavior changes
+- Invisible form protection executes a fresh verification on every submission;
+  it no longer reuses the previous 60 seconds' score and single-use token.
+- Direct npm `engine.verify()` callers receive an exception with `status: 400`
+  for malformed signal objects instead of a verification result.
+- Fingerprint cardinality uses fixed 15-minute windows, capped at 16 members
+  per bucket, rather than sliding retention.
+- Go and Python launcher access logs are off unless `FCAPTCHA_LOG_ACCESS=1`.
+- Importing the Node server exports `{ app, start }`; programmatic consumers
+  call `start()` to open a listener. CLI startup is unchanged.
+
 ## [1.34.1] — 2026-08-30
 
 ### Fixed

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -69,8 +69,9 @@ data from other sites.
 
 ## What is retained, and for how long
 
-All of it is in process memory. **There is no database and nothing is written to
-disk.** Restart the server and every value below is gone.
+By default, security state is in process memory and disappears on restart.
+When `REDIS_URL` is configured, it lives in Redis with expiry; operators control
+Redis persistence and backups. FCaptcha itself does not write state to disk.
 
 | State | Keyed on | Lifetime |
 |---|---|---|
@@ -78,6 +79,7 @@ disk.** Restart the server and every value below is gone.
 | Spent PoW solutions (replay guard) | solution hash | 10 minutes |
 | Spent tokens (replay guard) | token signature | 10 minutes |
 | Suspicion ledger (adaptive cost) | site key + IP | 15 minutes |
+| Fingerprint cardinality | site + fingerprint / IP | 15-minute fixed windows; at most 16 members per bucket |
 | Rate-limit counters | site key + IP | 60-second windows |
 | Site-key state bounds | IP | 1 hour |
 | Siteverify idempotency cache | caller-supplied key | 5 minutes |
@@ -95,7 +97,11 @@ hostname, action and customer data your integration supplied. Tokens are valid f
 
 ## Logging
 
-Off by default. A self-hosted FCaptcha emits **no per-request logs** unless you
+Off by default. Go and Python access logging can be enabled separately with
+`FCAPTCHA_LOG_ACCESS=1`; it includes client addresses and request URLs, so its
+retention and access controls are the operator’s responsibility.
+
+A self-hosted FCaptcha emits **no verdict logs** unless you
 turn them on.
 
 `FCAPTCHA_LOG_VERDICTS=1` emits one JSON line per verification: score,
@@ -253,7 +259,7 @@ false-positive cost is measured in CI. Weigh that against your own requirement.
 
 If your assessment says the fingerprinting is more than you want:
 
-- `FCAPTCHA_LOG_VERDICTS` unset (the default) means no per-request logging.
+- Leave `FCAPTCHA_LOG_VERDICTS` and `FCAPTCHA_LOG_ACCESS` unset to keep request logging off.
 - Serve the widget from your own origin, which is the default, so no third-party
   request is made at all.
 - The signal collectors in `client/fcaptcha.js` are individually removable. Doing

--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ FCaptcha.render('captcha', {
 Overrides are HTML-escaped, so a string coming from a CMS or locale file cannot
 turn the widget into an injection point.
 
+For pages that mount and unmount widgets, call `FCaptcha.destroy(widgetId)` to
+release listeners, sensors, timers, and workers. Invisible sessions expose
+`session.destroy()`; the one-shot `FCaptcha.execute()` cleans itself up.
+
 **Invisible Mode (Zero-Click)**
 
 ```html
@@ -793,6 +797,10 @@ Set `action` (and optionally `cdata`) when you request the token —
 | `FCAPTCHA_PPROF_ADDR` | (Go) Listen address for pprof when enabled — keep it loopback-only | `127.0.0.1:3001` |
 | `FCAPTCHA_LOG_VERDICTS` | Log one privacy-safe JSON line per `/api/verify` and `/api/score` (score, recommendation, category scores, and per-hit category/score/confidence). Omits IP, user agent, raw signals, and free-text detection reasons. For observability/tuning (`1`/`true`/`yes`/`on`) | off |
 | `FCAPTCHA_LOG_VERDICTS_INCLUDE_RAW` | Also include the free-text detection `reason` in verdict logs. **Reasons can contain visitor-derived data** (reverse-DNS hostnames, UA/header fragments, form field ids) — only enable in trusted debugging contexts with no privacy obligations. Requires `FCAPTCHA_LOG_VERDICTS` | off |
+
+Go and Python HTTP access logs are off by default. Set `FCAPTCHA_LOG_ACCESS=1` to enable
+them; they include client addresses and request URLs. This is separate from
+`FCAPTCHA_LOG_VERDICTS`.
 
 ### Trusted proxies
 

--- a/client/fcaptcha.js
+++ b/client/fcaptcha.js
@@ -2315,6 +2315,8 @@
      * Spoofed values often don't match between contexts
      */
     async _checkWorkerConsistency() {
+      let worker;
+      let workerUrl;
       try {
         if (typeof Worker === 'undefined') {
           return { supported: false };
@@ -2338,7 +2340,8 @@
         `;
 
         const blob = new Blob([workerCode], { type: 'application/javascript' });
-        const worker = new Worker(URL.createObjectURL(blob));
+        workerUrl = URL.createObjectURL(blob);
+        worker = new Worker(workerUrl);
 
         const workerData = await new Promise((resolve, reject) => {
           const timeout = setTimeout(() => reject(new Error('timeout')), 2000);
@@ -2386,6 +2389,9 @@
         };
       } catch (e) {
         return { supported: false, error: true };
+      } finally {
+        if (worker) worker.terminate();
+        if (workerUrl) URL.revokeObjectURL(workerUrl);
       }
     }
   }
@@ -2406,7 +2412,12 @@
   // ============================================================
 
   class PoWManager {
-    constructor() {
+    constructor(serverUrl = null) {
+      this.serverUrl = serverUrl;
+      this.generation = 0;
+      this.fetchPromise = null;
+      this.fetchController = null;
+      this._cancelSolve = null;
       this.workers = [];
       this.challenge = null;
       this.challengeReceivedAt = null;
@@ -2468,7 +2479,8 @@
       `;
 
       const blob = new Blob([workerCode], { type: 'application/javascript' });
-      return new Worker(URL.createObjectURL(blob));
+      const url = URL.createObjectURL(blob);
+      try { return new Worker(url); } finally { URL.revokeObjectURL(url); }
     }
 
     // Pick a worker count that uses available cores without monopolizing them.
@@ -2486,20 +2498,44 @@
     }
 
     // Fetch challenge from server
-    async fetchChallenge(siteKey) {
-      const serverUrl = FCaptcha.serverUrl;
+    async ensureChallenge(siteKey) {
+      if (this.fetchPromise) await this.fetchPromise;
+      if (!this.challenge || this.solution || this.challengeExpired()) {
+        await this.fetchChallenge(siteKey);
+      }
+      return this.challenge;
+    }
+
+    fetchChallenge(siteKey) {
+      if (this.fetchPromise) return this.fetchPromise;
+      const generation = this.generation;
+      this.fetchPromise = this._fetchChallenge(siteKey).finally(() => {
+        if (generation === this.generation) this.fetchPromise = null;
+      });
+      return this.fetchPromise;
+    }
+
+    async _fetchChallenge(siteKey) {
+      const generation = this.generation;
+      const serverUrl = this.serverUrl || FCaptcha.serverUrl;
       if (!serverUrl) {
         // Fallback to local challenge generation
         return this._generateLocalChallenge();
       }
 
       try {
-        const response = await fetch(`${serverUrl}/api/pow/challenge?siteKey=${encodeURIComponent(siteKey || 'default')}`);
+        this.fetchController = new AbortController();
+        const response = await fetch(`${serverUrl}/api/pow/challenge?siteKey=${encodeURIComponent(siteKey || 'default')}`, {
+          signal: this.fetchController.signal
+        });
         if (!response.ok) {
           console.warn('PoW challenge fetch failed (status ' + response.status + '), using local challenge');
           return this._generateLocalChallenge();
         }
-        this.challenge = await response.json();
+        const challenge = await response.json();
+        if (generation !== this.generation) throw new Error('Challenge fetch cancelled');
+        this.challenge = challenge;
+        this.solution = null;
         // Time the wait from when the challenge arrived, not from the
         // timestamp inside it. Receipt is necessarily later than issue, so a
         // wait measured from here always clears the server's floor — and it
@@ -2507,6 +2543,7 @@
         this.challengeReceivedAt = Date.now();
         return this.challenge;
       } catch (e) {
+        if (generation !== this.generation || e.name === 'AbortError') throw e;
         console.warn('PoW challenge fetch failed, using local challenge:', e);
         return this._generateLocalChallenge();
       }
@@ -2564,22 +2601,27 @@
     }
 
     // Solve with signals hash bound into PoW input
-    async solveWithSignalsHash(siteKey, signalsHash) {
-      return this._solve(siteKey, signalsHash);
+    async solveWithSignalsHash(siteKey, signalsHash, challenge = null) {
+      return this._solve(siteKey, signalsHash, challenge);
     }
 
-    async _solve(siteKey, signalsHash) {
+    async _solve(siteKey, signalsHash, boundChallenge = null) {
       if (this.solving) return this.solvePromise;
 
-      // Fetch a challenge if there isn't one, or if the one we have is spent.
-      if (!this.challenge || this.challengeExpired()) {
-        await this.fetchChallenge(siteKey);
+      if (boundChallenge) {
+        if (this.challenge !== boundChallenge || this.challengeExpired()) {
+          throw new Error('Challenge changed before solving');
+        }
+      } else {
+        await this.ensureChallenge(siteKey);
       }
+      const generation = this.generation;
 
       this.solving = true;
       this.startTime = performance.now();
 
       this.solvePromise = new Promise((resolve, reject) => {
+        this._cancelSolve = () => reject(new Error('PoW cancelled'));
         const threads = this._threadCount();
         let settled = false;
 
@@ -2591,12 +2633,15 @@
           // since there is no solution to hold back.
           if (fn === resolve) {
             this._awaitMinAge().then(() => {
+              if (generation !== this.generation) return;
               this.solving = false;
+              this._cancelSolve = null;
               fn(value);
             });
             return;
           }
           this.solving = false;
+          this._cancelSolve = null;
           fn(value);
         };
 
@@ -2654,6 +2699,12 @@
 
     // Reset for new challenge
     reset() {
+      this.generation++;
+      if (this.fetchController) this.fetchController.abort();
+      this.fetchController = null;
+      this.fetchPromise = null;
+      if (this._cancelSolve) this._cancelSolve();
+      this._cancelSolve = null;
       this._terminateWorkers();
       this.challenge = null;
       this.challengeReceivedAt = null;
@@ -2661,15 +2712,6 @@
       this.solving = false;
       this.solvePromise = null;
     }
-  }
-
-  // Global PoW manager - starts solving on page load
-  let globalPoWManager = null;
-  function getPoWManager() {
-    if (!globalPoWManager) {
-      globalPoWManager = new PoWManager();
-    }
-    return globalPoWManager;
   }
 
   // ============================================================
@@ -2785,10 +2827,12 @@
       this.environmental = new EnvironmentalCollector();
       this.temporal = new TemporalCollector();
       this.sensor = new SensorCollector();
-      this.powManager = getPoWManager();
+      this.powManager = new PoWManager();
       this.token = null;
       this.verified = false;
 
+      this.destroyed = false;
+      this._listenerController = new AbortController();
       this._init();
     }
 
@@ -2951,41 +2995,41 @@
 
     _attachListeners() {
       // Global tracking
-      document.addEventListener('mousemove', (e) => this.behavioral.recordMouseMove(e), { passive: true });
-      document.addEventListener('mousedown', (e) => this.behavioral.recordMouseDown(e), { passive: true });
-      document.addEventListener('mouseup', (e) => this.behavioral.recordMouseUp(e), { passive: true });
-      document.addEventListener('scroll', (e) => this.behavioral.recordScroll(e), { passive: true });
-      document.addEventListener('keydown', (e) => this.behavioral.recordKeyEvent(e), { passive: true });
-      document.addEventListener('keyup', (e) => this.behavioral.recordKeyEvent(e), { passive: true });
-      document.addEventListener('touchstart', (e) => this.behavioral.recordTouch(e), { passive: true });
-      document.addEventListener('touchmove', (e) => this.behavioral.recordTouch(e), { passive: true });
-      document.addEventListener('pointermove', (e) => this.behavioral.recordPointer(e), { passive: true });
-      document.addEventListener('pointerdown', (e) => this.behavioral.recordPointer(e), { passive: true });
-      document.addEventListener('pointerup', (e) => this.behavioral.recordPointer(e), { passive: true });
-      document.addEventListener('focus', (e) => this.behavioral.recordFocus(e), { passive: true, capture: true });
-      document.addEventListener('blur', (e) => this.behavioral.recordFocus(e), { passive: true, capture: true });
+      document.addEventListener('mousemove', (e) => this.behavioral.recordMouseMove(e), { passive: true, signal: this._listenerController.signal });
+      document.addEventListener('mousedown', (e) => this.behavioral.recordMouseDown(e), { passive: true, signal: this._listenerController.signal });
+      document.addEventListener('mouseup', (e) => this.behavioral.recordMouseUp(e), { passive: true, signal: this._listenerController.signal });
+      document.addEventListener('scroll', (e) => this.behavioral.recordScroll(e), { passive: true, signal: this._listenerController.signal });
+      document.addEventListener('keydown', (e) => this.behavioral.recordKeyEvent(e), { passive: true, signal: this._listenerController.signal });
+      document.addEventListener('keyup', (e) => this.behavioral.recordKeyEvent(e), { passive: true, signal: this._listenerController.signal });
+      document.addEventListener('touchstart', (e) => this.behavioral.recordTouch(e), { passive: true, signal: this._listenerController.signal });
+      document.addEventListener('touchmove', (e) => this.behavioral.recordTouch(e), { passive: true, signal: this._listenerController.signal });
+      document.addEventListener('pointermove', (e) => this.behavioral.recordPointer(e), { passive: true, signal: this._listenerController.signal });
+      document.addEventListener('pointerdown', (e) => this.behavioral.recordPointer(e), { passive: true, signal: this._listenerController.signal });
+      document.addEventListener('pointerup', (e) => this.behavioral.recordPointer(e), { passive: true, signal: this._listenerController.signal });
+      document.addEventListener('focus', (e) => this.behavioral.recordFocus(e), { passive: true, capture: true, signal: this._listenerController.signal });
+      document.addEventListener('blur', (e) => this.behavioral.recordFocus(e), { passive: true, capture: true, signal: this._listenerController.signal });
 
       // Passive device sensors (no permission request; absence treated as neutral server-side)
       this.sensor.attach();
 
       // First interaction
       const recordFirst = () => this.temporal.recordFirstInteraction();
-      document.addEventListener('mousemove', recordFirst, { once: true });
-      document.addEventListener('touchstart', recordFirst, { once: true });
-      document.addEventListener('keydown', recordFirst, { once: true });
+      document.addEventListener('mousemove', recordFirst, { once: true, signal: this._listenerController.signal });
+      document.addEventListener('touchstart', recordFirst, { once: true, signal: this._listenerController.signal });
+      document.addEventListener('keydown', recordFirst, { once: true, signal: this._listenerController.signal });
 
       // Checkbox click
-      this.checkbox.addEventListener('click', (e) => this._handleClick(e));
+      this.checkbox.addEventListener('click', (e) => this._handleClick(e), { signal: this._listenerController.signal });
       this.checkbox.addEventListener('keydown', (e) => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
           this._handleClick(e);
         }
-      });
+      }, { signal: this._listenerController.signal });
     }
 
     async _handleClick(e) {
-      if (this.verified || this.checkbox.classList.contains('loading')) return;
+      if (this.destroyed || this.verified || this.checkbox.classList.contains('loading')) return;
 
       const clickTime = performance.now();
       const rect = this.checkbox.getBoundingClientRect();
@@ -3010,6 +3054,10 @@
 
         const formAnalysis = getFormAnalyzer().analyze();
 
+        if (this.destroyed) return;
+        const challenge = await this.powManager.ensureChallenge(this.options.siteKey);
+        if (this.destroyed) return;
+
         // Step 2: Build signals object (without pow timing)
         const sensorData = this.sensor.analyze();
         const signals = {
@@ -3020,7 +3068,7 @@
           meta: {
             widgetId: this.id,
             siteKey: this.options.siteKey,
-            challengeNonce: this.powManager.challenge?.nonce || null,
+            challengeNonce: challenge.nonce || null,
             timestamp: Date.now(),
             userAgent: navigator.userAgent,
             screenSize: `${screen.width}x${screen.height}`,
@@ -3034,7 +3082,7 @@
         const signalsHash = await sha256(signalsJson);
 
         // Step 4: Solve PoW with signalsHash bound
-        const powSolution = await this.powManager.solveWithSignalsHash(this.options.siteKey, signalsHash);
+        const powSolution = await this.powManager.solveWithSignalsHash(this.options.siteKey, signalsHash, challenge);
 
         // Step 5: Build powTiming separately (not part of committed signals)
         const powTiming = {
@@ -3131,6 +3179,7 @@
     }
 
     _showSuccess(token) {
+      if (this.destroyed) return;
       this.verified = true;
       this.token = token;
       this.checkbox.classList.remove('loading');
@@ -3168,6 +3217,7 @@
     }
 
     _showFailure(message) {
+      if (this.destroyed) return;
       this.checkbox.classList.remove('loading');
       this.checkbox.classList.add('failed');
       this.spinner.style.display = 'none';
@@ -3188,15 +3238,29 @@
       this.powManager.reset();
       this._fetchChallenge();
 
-      setTimeout(() => {
+      clearTimeout(this._failureTimer);
+      this._failureTimer = setTimeout(() => {
         this.checkbox.classList.remove('failed');
         this.label.textContent = this.strings.label;
       }, 3000);
     }
 
+    destroy() {
+      this.destroyed = true;
+      this._listenerController.abort();
+      this.sensor.detach();
+      this.powManager.reset();
+      this._clearTokenExpiry();
+      clearTimeout(this._failureTimer);
+      FCaptcha.widgets.delete(this.id);
+      this.container.innerHTML = '';
+    }
+
     getToken() { return this.token; }
 
     reset() {
+      if (this.destroyed) return;
+      clearTimeout(this._failureTimer);
       this._clearTokenExpiry();
       this.verified = false;
       this.token = null;
@@ -3235,11 +3299,13 @@
       this.environmental = new EnvironmentalCollector();
       this.temporal = new TemporalCollector();
       this.sensor = new SensorCollector();
-      this.powManager = new PoWManager();
+      this.powManager = new PoWManager(this.options.serverUrl);
       this.startTime = Date.now();
       this.lastScore = null;
       this.listeners = [];
 
+      this.destroyed = false;
+      this._listenerController = new AbortController();
       this._init();
     }
 
@@ -3247,10 +3313,10 @@
       this._attachListeners();
 
       const recordFirst = () => this.temporal.recordFirstInteraction();
-      document.addEventListener('mousemove', recordFirst, { once: true });
-      document.addEventListener('touchstart', recordFirst, { once: true });
-      document.addEventListener('keydown', recordFirst, { once: true });
-      document.addEventListener('scroll', recordFirst, { once: true });
+      document.addEventListener('mousemove', recordFirst, { once: true, signal: this._listenerController.signal });
+      document.addEventListener('touchstart', recordFirst, { once: true, signal: this._listenerController.signal });
+      document.addEventListener('keydown', recordFirst, { once: true, signal: this._listenerController.signal });
+      document.addEventListener('scroll', recordFirst, { once: true, signal: this._listenerController.signal });
 
       if (this.options.autoScore) this._attachToForms();
 
@@ -3285,7 +3351,7 @@
 
       for (const [event, handler] of Object.entries(handlers)) {
         const opts = event === 'focus' || event === 'blur' ?
-          { passive: true, capture: true } : { passive: true };
+          { passive: true, capture: true, signal: this._listenerController.signal } : { passive: true, signal: this._listenerController.signal };
         document.addEventListener(event, handler, opts);
         this.listeners.push({ event, handler, opts });
       }
@@ -3307,90 +3373,107 @@
           form.appendChild(tokenField);
         }
 
-        if (!this.lastScore || Date.now() - this.lastScore.timestamp > 60000) {
-          e.preventDefault();
+        e.preventDefault();
 
-          try {
-            const result = await this.execute(form.dataset.fcaptchaAction || 'form_submit');
-            tokenField.value = result.token || '';
+        try {
+          const result = await this.execute(form.dataset.fcaptchaAction || 'form_submit');
+          if (this.destroyed) return;
+          tokenField.value = result.token || '';
 
-            if (result.success) {
-              form.submit();
-            } else {
-              document.dispatchEvent(new CustomEvent('fcaptcha:blocked', {
-                detail: { score: result.score, form }
-              }));
-            }
-          } catch (error) {
-            console.error('FCaptcha error:', error);
-            form.submit(); // Fail open
+          if (result.success) {
+            form.submit();
+          } else {
+            document.dispatchEvent(new CustomEvent('fcaptcha:blocked', {
+              detail: { score: result.score, form }
+            }));
           }
-        } else {
-          tokenField.value = this.lastScore.token || '';
+        } catch (error) {
+          if (this.destroyed) return;
+          console.error('FCaptcha error:', error);
+          form.submit(); // Fail open
         }
-      });
+      }, { signal: this._listenerController.signal });
     }
 
-    async execute(action = '', cdata = '') {
-      const elapsed = Date.now() - this.startTime;
-      if (elapsed < this.options.minCollectionTime) {
-        await new Promise(r => setTimeout(r, this.options.minCollectionTime - elapsed));
-      }
+    execute(action = '', cdata = '') {
+      const run = () => {
+        if (this.destroyed) throw new Error('Session destroyed');
+        return this._execute(action, cdata);
+      };
+      const next = (this._executeQueue || Promise.resolve()).then(run, run);
+      this._executeQueue = next.catch(() => {});
+      return next;
+    }
 
-      // Step 1: Collect all signals
-      const behavioralData = this.behavioral.analyze();
-      const envData = this.environmental.collect();
-
-      // Collect temporal data WITHOUT pow timing (not yet solved)
-      const temporalData = this.temporal.collect(Date.now());
-
-      const [rafData, asyncEnvData] = await Promise.all([
-        this.environmental.measureRAFConsistency(),
-        this.environmental.collectAsync()
-      ]);
-
-      const formAnalysis = getFormAnalyzer().analyze();
-
-      // Step 2: Build signals object (without pow timing)
-      const sensorData = this.sensor.analyze();
-      const signals = {
-        behavioral: behavioralData,
-        environmental: { ...envData, rafConsistency: rafData, ...asyncEnvData, sensor: sensorData },
-        temporal: temporalData,
-        formAnalysis: formAnalysis,
-        meta: {
-          sessionId: this.id,
-          siteKey: this.options.siteKey,
-          action,
-          challengeNonce: this.powManager.challenge?.nonce || null,
-          timestamp: Date.now(),
-          userAgent: navigator.userAgent,
-          screenSize: `${screen.width}x${screen.height}`,
-          viewportSize: `${window.innerWidth}x${window.innerHeight}`,
-          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-          sessionDuration: Date.now() - this.startTime,
-          invisible: true
+    async _execute(action, cdata) {
+      try {
+        const elapsed = Date.now() - this.startTime;
+        if (elapsed < this.options.minCollectionTime) {
+          await new Promise(r => setTimeout(r, this.options.minCollectionTime - elapsed));
         }
-      };
 
-      // Step 3: Serialize and hash signals for PoW binding
-      const signalsJson = JSON.stringify(signals);
-      const signalsHash = await sha256(signalsJson);
+        // Step 1: Collect all signals
+        const behavioralData = this.behavioral.analyze();
+        const envData = this.environmental.collect();
 
-      // Step 4: Solve PoW with signalsHash bound
-      const powSolution = await this.powManager.solveWithSignalsHash(this.options.siteKey, signalsHash);
+        // Collect temporal data WITHOUT pow timing (not yet solved)
+        const temporalData = this.temporal.collect(Date.now());
 
-      // Step 5: Build powTiming separately
-      const powTiming = {
-        duration: powSolution.duration,
-        iterations: powSolution.iterations,
-        difficulty: powSolution.difficulty
-      };
+        const [rafData, asyncEnvData] = await Promise.all([
+          this.environmental.measureRAFConsistency(),
+          this.environmental.collectAsync()
+        ]);
 
-      // Step 6: Submit
-      const result = await this._score(signals, action, powSolution, signalsJson, signalsHash, powTiming, cdata);
-      this.lastScore = { ...result, timestamp: Date.now() };
-      return result;
+        const formAnalysis = getFormAnalyzer().analyze();
+
+        if (this.destroyed) throw new Error('Session destroyed');
+        const challenge = await this.powManager.ensureChallenge(this.options.siteKey);
+        if (this.destroyed) throw new Error('Session destroyed');
+
+        // Step 2: Build signals object (without pow timing)
+        const sensorData = this.sensor.analyze();
+        const signals = {
+          behavioral: behavioralData,
+          environmental: { ...envData, rafConsistency: rafData, ...asyncEnvData, sensor: sensorData },
+          temporal: temporalData,
+          formAnalysis: formAnalysis,
+          meta: {
+            sessionId: this.id,
+            siteKey: this.options.siteKey,
+            action,
+            challengeNonce: challenge.nonce || null,
+            timestamp: Date.now(),
+            userAgent: navigator.userAgent,
+            screenSize: `${screen.width}x${screen.height}`,
+            viewportSize: `${window.innerWidth}x${window.innerHeight}`,
+            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            sessionDuration: Date.now() - this.startTime,
+            invisible: true
+          }
+        };
+
+        // Step 3: Serialize and hash signals for PoW binding
+        const signalsJson = JSON.stringify(signals);
+        const signalsHash = await sha256(signalsJson);
+
+        // Step 4: Solve PoW with signalsHash bound
+        const powSolution = await this.powManager.solveWithSignalsHash(this.options.siteKey, signalsHash, challenge);
+
+        // Step 5: Build powTiming separately
+        const powTiming = {
+          duration: powSolution.duration,
+          iterations: powSolution.iterations,
+          difficulty: powSolution.difficulty
+        };
+
+        // Step 6: Submit
+        const result = await this._score(signals, action, powSolution, signalsJson, signalsHash, powTiming, cdata);
+        if (this.destroyed) throw new Error('Session destroyed');
+        this.lastScore = { ...result, timestamp: Date.now() };
+        return result;
+      } finally {
+        this.powManager.reset();
+      }
     }
 
     async _score(signals, action, powSolution = null, signalsJson = null, signalsHash = null, powTiming = null, cdata = '') {
@@ -3475,6 +3558,10 @@
     getScore() { return this.lastScore; }
 
     destroy() {
+      this.destroyed = true;
+      this._listenerController.abort();
+      this.sensor.detach();
+      FCaptcha.widgets.delete(this.id);
       for (const { event, handler, opts } of this.listeners) {
         document.removeEventListener(event, handler, opts);
       }
@@ -3504,9 +3591,11 @@
       powDifficulty: options.powDifficulty || 3
     });
 
-    const result = await session.execute(options.action || '', options.cdata || '');
-    session.destroy();
-    return result;
+    try {
+      return await session.execute(options.action || '', options.cdata || '');
+    } finally {
+      session.destroy();
+    }
   };
 
   FCaptcha.render = function(container, options) {
@@ -3518,6 +3607,11 @@
   FCaptcha.getResponse = function(widgetId) {
     const widget = this.widgets.get(widgetId);
     return widget ? widget.getToken() : null;
+  };
+
+  FCaptcha.destroy = function(widgetId) {
+    const widget = this.widgets.get(widgetId);
+    if (widget && widget.destroy) widget.destroy();
   };
 
   FCaptcha.reset = function(widgetId) {

--- a/server-go/main.go
+++ b/server-go/main.go
@@ -519,11 +519,6 @@ func verifyHandler(engine *ScoringEngine, trust *ProxyTrust, siteKeys *SiteKeyGu
 			http.Error(w, "Invalid signals", http.StatusBadRequest)
 			return
 		}
-		extraDetections := []DetectionResult{}
-		if !commitmentValid {
-			req.PowSolution = nil
-			extraDetections = append(extraDetections, commitmentFailureDetection())
-		}
 
 		// Inject powTiming into signals.temporal.pow
 		if req.PowTiming != nil {
@@ -548,12 +543,7 @@ func verifyHandler(engine *ScoringEngine, trust *ProxyTrust, siteKeys *SiteKeyGu
 		// client's click analysis is present and meaningful.
 		SetInteractionMode(signals, true)
 
-		result := engine.VerifyWithHeaders(signals, ip, req.SiteKey, userAgent, headers, ja3Hash, ja4s.Lookup(r.RemoteAddr), peerTrusted, webBotAuth, TokenBinding{Action: req.Action, CData: req.CData}, req.PowSolution)
-
-		// Add signal commitment detections to results
-		if len(extraDetections) > 0 {
-			result.Detections = append(extraDetections, result.Detections...)
-		}
+		result := engine.verifyWithHeaders(signals, ip, req.SiteKey, userAgent, headers, ja3Hash, ja4s.Lookup(r.RemoteAddr), peerTrusted, webBotAuth, TokenBinding{Action: req.Action, CData: req.CData}, commitmentValid, req.PowSolution)
 
 		logVerdict("verify", req.SiteKey, result)
 
@@ -624,11 +614,6 @@ func invisibleScoreHandler(engine *ScoringEngine, trust *ProxyTrust, siteKeys *S
 			http.Error(w, "Invalid signals", http.StatusBadRequest)
 			return
 		}
-		scoreExtraDetections := []DetectionResult{}
-		if !commitmentValid {
-			req.PowSolution = nil
-			scoreExtraDetections = append(scoreExtraDetections, commitmentFailureDetection())
-		}
 
 		// Inject powTiming
 		if req.PowTiming != nil {
@@ -650,10 +635,7 @@ func invisibleScoreHandler(engine *ScoringEngine, trust *ProxyTrust, siteKeys *S
 		// Invisible scoring: no widget, so no click analysis in the signals.
 		SetInteractionMode(signals, false)
 
-		result := engine.VerifyWithHeaders(signals, ip, req.SiteKey, userAgent, scoreHeaders, ja3, ja4s.Lookup(r.RemoteAddr), peerTrusted, webBotAuth, TokenBinding{Action: req.Action, CData: req.CData}, req.PowSolution)
-		if len(scoreExtraDetections) > 0 {
-			result.Detections = append(scoreExtraDetections, result.Detections...)
-		}
+		result := engine.verifyWithHeaders(signals, ip, req.SiteKey, userAgent, scoreHeaders, ja3, ja4s.Lookup(r.RemoteAddr), peerTrusted, webBotAuth, TokenBinding{Action: req.Action, CData: req.CData}, commitmentValid, req.PowSolution)
 
 		logVerdict("score", req.SiteKey, result)
 

--- a/server-go/main.go
+++ b/server-go/main.go
@@ -269,7 +269,9 @@ func main() {
 	// address to the datacenter, Tor/VPN and rate-limit checks and leave no
 	// un-forged source to fall back on. ProxyTrust.ClientIP does the same job
 	// gated on the peer.
-	r.Use(middleware.Logger)
+	if envFlagEnabled("FCAPTCHA_LOG_ACCESS") {
+		r.Use(middleware.Logger)
+	}
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Timeout(30 * time.Second))
 	r.Use(limitRequestBody)
@@ -512,29 +514,15 @@ func verifyHandler(engine *ScoringEngine, trust *ProxyTrust, siteKeys *SiteKeyGu
 		// TLS fingerprint would just claim a stock Chrome one.
 		ja3Hash := trust.TrustedHeader(r, "X-JA3-Hash")
 
-		// Verify signal commitment
-		signals := req.Signals
-		clientSignalsHash := ""
-		if req.PowSolution != nil {
-			clientSignalsHash = req.PowSolution.SignalsHash
+		signals, commitmentValid, err := resolveCommittedSignals(req.Signals, req.SignalsJson, req.PowSolution)
+		if err != nil {
+			http.Error(w, "Invalid signals", http.StatusBadRequest)
+			return
 		}
-		extraDetections := make([]DetectionResult, 0)
-		if req.SignalsJson != "" && clientSignalsHash != "" {
-			computedHash := sha256.Sum256([]byte(req.SignalsJson))
-			computedHashHex := hex.EncodeToString(computedHash[:])
-			if computedHashHex != clientSignalsHash {
-				extraDetections = append(extraDetections, DetectionResult{
-					Category:   CategoryBot,
-					Score:      0.95,
-					Confidence: 0.95,
-					Reason:     "Signals tampered after PoW (signalsHash mismatch)",
-				})
-			}
-			// Use signalsJson as the canonical signals source
-			var parsed map[string]interface{}
-			if err := json.Unmarshal([]byte(req.SignalsJson), &parsed); err == nil {
-				signals = parsed
-			}
+		extraDetections := []DetectionResult{}
+		if !commitmentValid {
+			req.PowSolution = nil
+			extraDetections = append(extraDetections, commitmentFailureDetection())
 		}
 
 		// Inject powTiming into signals.temporal.pow
@@ -631,28 +619,15 @@ func invisibleScoreHandler(engine *ScoringEngine, trust *ProxyTrust, siteKeys *S
 		}
 		ja3 := trust.TrustedHeader(r, "X-JA3-Hash")
 
-		// Verify signal commitment
-		signals := req.Signals
-		clientSigHash := ""
-		if req.PowSolution != nil {
-			clientSigHash = req.PowSolution.SignalsHash
+		signals, commitmentValid, err := resolveCommittedSignals(req.Signals, req.SignalsJson, req.PowSolution)
+		if err != nil {
+			http.Error(w, "Invalid signals", http.StatusBadRequest)
+			return
 		}
-		scoreExtraDetections := make([]DetectionResult, 0)
-		if req.SignalsJson != "" && clientSigHash != "" {
-			cHash := sha256.Sum256([]byte(req.SignalsJson))
-			cHashHex := hex.EncodeToString(cHash[:])
-			if cHashHex != clientSigHash {
-				scoreExtraDetections = append(scoreExtraDetections, DetectionResult{
-					Category:   CategoryBot,
-					Score:      0.95,
-					Confidence: 0.95,
-					Reason:     "Signals tampered after PoW (signalsHash mismatch)",
-				})
-			}
-			var parsed map[string]interface{}
-			if err := json.Unmarshal([]byte(req.SignalsJson), &parsed); err == nil {
-				signals = parsed
-			}
+		scoreExtraDetections := []DetectionResult{}
+		if !commitmentValid {
+			req.PowSolution = nil
+			scoreExtraDetections = append(scoreExtraDetections, commitmentFailureDetection())
 		}
 
 		// Inject powTiming
@@ -807,4 +782,29 @@ func challengeHandler(engine *ScoringEngine) http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp)
 	}
+}
+
+// Resolve the exact committed bytes before injecting server-derived signals.
+func resolveCommittedSignals(signals map[string]interface{}, raw string, proof *PoWSolution) (map[string]interface{}, bool, error) {
+	valid := true
+	if proof != nil && proof.SignalsHash != "" {
+		hash := sha256.Sum256([]byte(raw))
+		valid = raw != "" && hex.EncodeToString(hash[:]) == proof.SignalsHash
+		if raw != "" {
+			var parsed map[string]interface{}
+			if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+				return nil, false, err
+			}
+			signals = parsed
+		}
+	}
+	if signals == nil {
+		return nil, false, fmt.Errorf("signals must be an object")
+	}
+	return signals, valid, nil
+}
+
+func commitmentFailureDetection() DetectionResult {
+	return DetectionResult{Category: CategoryBot, Score: 0.95, Confidence: 0.95,
+		Reason: "Signals tampered after PoW (signalsHash mismatch)"}
 }

--- a/server-go/scoring.go
+++ b/server-go/scoring.go
@@ -493,8 +493,16 @@ func compileUAPatterns() []*regexp.Regexp {
 // request-context struct. Left positional for now so the vendored copy in
 // fcaptcha-cloud stays a straight file copy rather than a port.
 func (e *ScoringEngine) VerifyWithHeaders(signals map[string]interface{}, ip, siteKey, userAgent string, headers map[string]string, ja3Hash, nativeJA4 string, peerTrusted bool, preDetections []DetectionResult, binding TokenBinding, powSolution ...*PoWSolution) *VerificationResult {
+	return e.verifyWithHeaders(signals, ip, siteKey, userAgent, headers, ja3Hash, nativeJA4, peerTrusted, preDetections, binding, true, powSolution...)
+}
+
+// commitmentValid is supplied only by the HTTP parser, never by signal fields.
+func (e *ScoringEngine) verifyWithHeaders(signals map[string]interface{}, ip, siteKey, userAgent string, headers map[string]string, ja3Hash, nativeJA4 string, peerTrusted bool, preDetections []DetectionResult, binding TokenBinding, commitmentValid bool, powSolution ...*PoWSolution) *VerificationResult {
 	detections := make([]DetectionResult, 0, len(preDetections)+8)
 	detections = append(detections, preDetections...)
+	if !commitmentValid {
+		detections = append(detections, commitmentFailureDetection())
+	}
 
 	// Verify PoW if provided.
 	//
@@ -539,7 +547,7 @@ func (e *ScoringEngine) VerifyWithHeaders(signals map[string]interface{}, ip, si
 				// author, in an ordinary browser.
 			})
 		} else {
-			powSatisfied = powResult.ServerElapsed >= max(baseMinAgeMs, powResult.MinAgeMs)
+			powSatisfied = commitmentValid && powResult.ServerElapsed >= max(baseMinAgeMs, powResult.MinAgeMs)
 		}
 
 		// Verify challenge nonce binding

--- a/server-go/scoring.go
+++ b/server-go/scoring.go
@@ -313,16 +313,14 @@ type RateLimiter struct {
 // FingerprintStore tracks fingerprint patterns
 type FingerprintStore struct {
 	mu             sync.RWMutex
-	fingerprints   map[string]*FingerprintData
-	ipFingerprints map[string]map[string]bool
+	fingerprints   *expirable.LRU[string, map[string]bool]
+	ipFingerprints *expirable.LRU[string, map[string]bool]
 	redis          *redis.Client
 }
 
-type FingerprintData struct {
-	FirstSeen int64
-	Count     int
-	IPs       map[string]bool
-}
+const fingerprintMembersCap = 16
+const fingerprintEntriesCap = 100000
+const fingerprintTTL = 15 * time.Minute
 
 // TokenStore prevents token replay attacks. Backed by a bounded LRU with TTL
 // so the store size is capped under sustained load and the previous O(n)
@@ -445,8 +443,8 @@ func newRedisRateLimiter(client *redis.Client) *RateLimiter {
 
 func newFingerprintStore() *FingerprintStore {
 	return &FingerprintStore{
-		fingerprints:   make(map[string]*FingerprintData),
-		ipFingerprints: make(map[string]map[string]bool),
+		fingerprints:   expirable.NewLRU[string, map[string]bool](fingerprintEntriesCap, nil, fingerprintTTL),
+		ipFingerprints: expirable.NewLRU[string, map[string]bool](fingerprintEntriesCap, nil, fingerprintTTL),
 	}
 }
 
@@ -541,7 +539,7 @@ func (e *ScoringEngine) VerifyWithHeaders(signals map[string]interface{}, ip, si
 				// author, in an ordinary browser.
 			})
 		} else {
-			powSatisfied = true
+			powSatisfied = powResult.ServerElapsed >= max(baseMinAgeMs, powResult.MinAgeMs)
 		}
 
 		// Verify challenge nonce binding
@@ -567,14 +565,8 @@ func (e *ScoringEngine) VerifyWithHeaders(signals map[string]interface{}, ip, si
 			}
 		}
 
-		// Two thresholds, because they mean different things. Under the
-		// universal baseline nothing legitimate can have happened: no human
-		// completes an interaction that fast, so it scores as it always has.
-		//
-		// Between the baseline and this source's own elevated floor is weaker
-		// evidence. A client that predates adaptive cost does not know to wait,
-		// and neither does one served from a stale cache, so a full-strength
-		// penalty there would punish the wrong people. It contributes instead.
+		// Timing diagnostics distinguish baseline and elevated-delay violations.
+		// The token gate above independently enforces the full advertised delay.
 		if powResult.Valid {
 			switch {
 			case powResult.ServerElapsed < baseMinAgeMs:
@@ -2394,6 +2386,7 @@ func (e *ScoringEngine) generateToken(ip, siteKey string, score float64, binding
 
 	data := map[string]interface{}{
 		"site_key":  siteKey,
+		"jti":       newTokenID(),
 		"timestamp": time.Now().Unix(),
 		"score":     math.Round(score*1000) / 1000,
 		"ip_hash":   hex.EncodeToString(ipHash[:4]),
@@ -2506,39 +2499,47 @@ func (rl *RateLimiter) Check(key string, windowSeconds int64, maxRequests int) (
 // Fingerprint Store Methods
 // ============================================================
 
+var recordFingerprintScript = redis.NewScript(`
+if redis.call('SCARD', KEYS[2]) >= 16 and redis.call('SISMEMBER', KEYS[2], ARGV[2]) == 0 then return 0 end
+if redis.call('SCARD', KEYS[1]) < 16 then redis.call('SADD', KEYS[1], ARGV[1]) end
+if redis.call('SCARD', KEYS[2]) < 16 then redis.call('SADD', KEYS[2], ARGV[2]) end
+for i = 1, 2 do
+  if redis.call('PTTL', KEYS[i]) < 0 then redis.call('PEXPIRE', KEYS[i], ARGV[3]) end
+end
+return 1
+`)
+
 func (fs *FingerprintStore) Record(fingerprint, ip, siteKey string) {
 	if fs.redis != nil {
 		ctx := context.Background()
 		fpKey := redisOpaqueKey("fingerprint:ips", siteKey+"|"+fingerprint)
 		ipKey := redisOpaqueKey("fingerprint:fps", ip)
-		pipe := fs.redis.TxPipeline()
-		pipe.SAdd(ctx, fpKey, redisOpaqueKey("value:ip", ip))
-		pipe.Expire(ctx, fpKey, suspicionWindow)
-		pipe.SAdd(ctx, ipKey, redisOpaqueKey("value:fp", fingerprint))
-		pipe.Expire(ctx, ipKey, suspicionWindow)
-		_, _ = pipe.Exec(ctx)
+		_, _ = recordFingerprintScript.Run(ctx, fs.redis, []string{fpKey, ipKey},
+			redisOpaqueKey("value:ip", ip), redisOpaqueKey("value:fp", fingerprint), fingerprintTTL.Milliseconds()).Result()
 		return
 	}
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
-
+	fps, ok := fs.ipFingerprints.Get(ip)
+	if !ok {
+		fps = make(map[string]bool)
+		fs.ipFingerprints.Add(ip, fps)
+	}
+	if len(fps) >= fingerprintMembersCap && !fps[fingerprint] {
+		return
+	}
+	if len(fps) < fingerprintMembersCap {
+		fps[fingerprint] = true
+	}
 	key := siteKey + ":" + fingerprint
-
-	if _, ok := fs.fingerprints[key]; !ok {
-		fs.fingerprints[key] = &FingerprintData{
-			FirstSeen: time.Now().Unix(),
-			Count:     0,
-			IPs:       make(map[string]bool),
-		}
+	ips, ok := fs.fingerprints.Get(key)
+	if !ok {
+		ips = make(map[string]bool)
+		fs.fingerprints.Add(key, ips)
 	}
-
-	fs.fingerprints[key].Count++
-	fs.fingerprints[key].IPs[ip] = true
-
-	if _, ok := fs.ipFingerprints[ip]; !ok {
-		fs.ipFingerprints[ip] = make(map[string]bool)
+	if len(ips) < fingerprintMembersCap {
+		ips[ip] = true
 	}
-	fs.ipFingerprints[ip][fingerprint] = true
 }
 
 func (fs *FingerprintStore) GetIPFingerprintCount(ip string) int {
@@ -2552,7 +2553,7 @@ func (fs *FingerprintStore) GetIPFingerprintCount(ip string) int {
 	fs.mu.RLock()
 	defer fs.mu.RUnlock()
 
-	if fps, ok := fs.ipFingerprints[ip]; ok {
+	if fps, ok := fs.ipFingerprints.Get(ip); ok {
 		return len(fps)
 	}
 	return 0
@@ -2570,8 +2571,8 @@ func (fs *FingerprintStore) GetFingerprintIPCount(fingerprint, siteKey string) i
 	defer fs.mu.RUnlock()
 
 	key := siteKey + ":" + fingerprint
-	if data, ok := fs.fingerprints[key]; ok {
-		return len(data.IPs)
+	if data, ok := fs.fingerprints.Get(key); ok {
+		return len(data)
 	}
 	return 0
 }
@@ -2675,4 +2676,12 @@ func hasWidgetInteraction(signals map[string]interface{}) bool {
 		return v
 	}
 	return true
+}
+
+func newTokenID() string {
+	var id [16]byte
+	if _, err := rand.Read(id[:]); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(id[:])
 }

--- a/server-go/security_test.go
+++ b/server-go/security_test.go
@@ -1,15 +1,105 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	miniredis "github.com/alicebob/miniredis/v2"
 	"github.com/hashicorp/golang-lru/v2/expirable"
 )
+
+func TestHTTPCommitmentFailureConsumesProofAndScoresTampering(t *testing.T) {
+	for _, endpoint := range []string{"verify", "score"} {
+		for _, tampered := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/tampered=%t", endpoint, tampered), func(t *testing.T) {
+				engine := NewScoringEngine("test-secret")
+				challenge := engine.GeneratePoWChallenge("site", "203.0.113.1", false)
+				challenge.Difficulty = 1
+				challenge.Timestamp = time.Now().UnixMilli() - 2000
+				if err := engine.powStore.putChallenge(challenge); err != nil {
+					t.Fatal(err)
+				}
+				signals := map[string]interface{}{
+					"behavioral": map[string]interface{}{"totalPoints": 60.0, "trajectoryLength": 400.0,
+						"microTremorScore": 0.5, "velocityVariance": 0.5, "approachPoints": 12.0,
+						"approachDirectness": 0.4, "explorationRatio": 0.35, "overshootCorrections": 2.0,
+						"interactionDuration": 4200.0},
+					"meta": map[string]interface{}{"challengeNonce": challenge.Nonce},
+				}
+				raw, err := json.Marshal(signals)
+				if err != nil {
+					t.Fatal(err)
+				}
+				digest := sha256.Sum256(raw)
+				signalsHash := hex.EncodeToString(digest[:])
+				boundChallenge := *challenge
+				boundChallenge.Prefix += ":" + signalsHash
+				proof := solvePoW(t, &boundChallenge)
+				proof.SignalsHash = signalsHash
+				if tampered {
+					// Equivalent JSON with different bytes must still fail the commitment.
+					raw = append(raw, ' ')
+				}
+				body, err := json.Marshal(map[string]interface{}{
+					"siteKey": "site", "signals": signals, "signalsJson": string(raw), "powSolution": proof,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				req := httptest.NewRequest(http.MethodPost, "/api/"+endpoint, bytes.NewReader(body))
+				req.RemoteAddr = "203.0.113.1:1234"
+				for key, value := range map[string]string{"Content-Type": "application/json", "User-Agent": "Mozilla/5.0",
+					"Accept": "text/html", "Accept-Language": "en-US", "Accept-Encoding": "gzip", "Connection": "keep-alive"} {
+					req.Header.Set(key, value)
+				}
+				trust, siteKeys, ja4s := NewProxyTrust("none"), NewSiteKeyGuard(nil, 8), newJA4Store(32)
+				handler := verifyHandler(engine, trust, siteKeys, ja4s)
+				if endpoint == "score" {
+					handler = invisibleScoreHandler(engine, trust, siteKeys, ja4s)
+				}
+				recorder := httptest.NewRecorder()
+				handler.ServeHTTP(recorder, req)
+				var result VerifyResponse
+				if recorder.Code != http.StatusOK {
+					t.Fatalf("unexpected response: %d %s", recorder.Code, recorder.Body.String())
+				}
+				if err := json.Unmarshal(recorder.Body.Bytes(), &result); err != nil {
+					t.Fatal(err)
+				}
+				if result.Success == tampered || (result.Token == "") != tampered {
+					t.Fatalf("unexpected verdict: %+v", result)
+				}
+				if stored, err := engine.powStore.getChallenge(challenge.ID); err != nil || stored != nil {
+					t.Fatalf("proof was not consumed: %v %v", stored, err)
+				}
+				if tampered {
+					if result.Reason != "pow_not_satisfied" {
+						t.Fatalf("unexpected denial reason: %s", result.Reason)
+					}
+					if endpoint == "verify" {
+						found := false
+						for _, detection := range result.Detections {
+							if detection.Reason == "No PoW solution provided" {
+								t.Fatal("valid proof incorrectly reported missing")
+							}
+							found = found || detection.Reason == commitmentFailureDetection().Reason
+						}
+						if !found || result.CategoryScores["bot"] < 0.9025 {
+							t.Fatalf("tampering was not scored: %+v", result)
+						}
+					}
+				}
+			})
+		}
+	}
+}
 
 func TestIndependentTokenIssuances(t *testing.T) {
 	engine := NewScoringEngine("test-secret")

--- a/server-go/security_test.go
+++ b/server-go/security_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"testing"
+	"time"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+	"github.com/hashicorp/golang-lru/v2/expirable"
+)
+
+func TestIndependentTokenIssuances(t *testing.T) {
+	engine := NewScoringEngine("test-secret")
+	a := engine.generateToken("ip", "site", 0.1, TokenBinding{})
+	b := engine.generateToken("ip", "site", 0.1, TokenBinding{})
+	if a == b {
+		t.Fatal("independent tokens collide")
+	}
+	if engine.VerifyToken(a)["valid"] != true || engine.VerifyToken(b)["valid"] != true {
+		t.Fatal("independent tokens must both verify")
+	}
+	if engine.VerifyToken(a)["valid"] != false {
+		t.Fatal("spent token replayed")
+	}
+}
+
+func TestCommitmentDoesNotMergeUncommittedFields(t *testing.T) {
+	raw := `{"meta":{"challengeNonce":"binding"}}`
+	digest := sha256.Sum256([]byte(raw))
+	proof := &PoWSolution{SignalsHash: hex.EncodeToString(digest[:])}
+	parsed, valid, err := resolveCommittedSignals(map[string]interface{}{"uncommitted": true}, raw, proof)
+	if err != nil || !valid || parsed["uncommitted"] != nil {
+		t.Fatalf("bad resolution: %v %v %v", parsed, valid, err)
+	}
+	_, valid, _ = resolveCommittedSignals(parsed, raw+" ", proof)
+	if valid {
+		t.Fatal("changed bytes accepted")
+	}
+	_, valid, _ = resolveCommittedSignals(parsed, "", proof)
+	if valid {
+		t.Fatal("missing committed bytes accepted")
+	}
+	proof.SignalsHash = "hash"
+	if _, _, err := resolveCommittedSignals(parsed, "null", proof); err == nil {
+		t.Fatal("null accepted")
+	}
+}
+
+func TestChallengeMinimumAgeGatesTokens(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		age, minimum int64
+		success      bool
+	}{
+		{"valid", 2000, 1500, true}, {"early", 0, 1500, false}, {"elevated", 2000, 60000, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			engine := NewScoringEngine("test-secret")
+			challenge := engine.GeneratePoWChallenge("site", "203.0.113.1", false)
+			challenge.Difficulty = 1
+			challenge.Timestamp = time.Now().UnixMilli() - test.age
+			challenge.MinAgeMs = test.minimum
+			if err := engine.powStore.putChallenge(challenge); err != nil {
+				t.Fatal(err)
+			}
+			proof := solvePoW(t, challenge)
+			signals := map[string]interface{}{
+				"behavioral": map[string]interface{}{"totalPoints": 60.0, "trajectoryLength": 400.0,
+					"microTremorScore": 0.5, "velocityVariance": 0.5, "approachPoints": 12.0,
+					"approachDirectness": 0.4, "explorationRatio": 0.35, "overshootCorrections": 2.0,
+					"interactionDuration": 4200.0},
+				"meta": map[string]interface{}{"challengeNonce": challenge.Nonce},
+			}
+			headers := map[string]string{"accept": "text/html", "accept-language": "en-US", "accept-encoding": "gzip", "connection": "keep-alive"}
+			result := engine.VerifyWithHeaders(signals, "203.0.113.1", "site", "Mozilla/5.0", headers, "", "", false, nil, TokenBinding{}, proof)
+			if result.Success != test.success {
+				t.Fatalf("unexpected result: %+v", result)
+			}
+		})
+	}
+}
+
+func TestFingerprintBoundsAndRedisExpiry(t *testing.T) {
+	redisServer := miniredis.RunT(t)
+	shared := NewScoringEngineWithRedis("test-secret", "redis://"+redisServer.Addr()).fingerprintStore
+	local := newFingerprintStore()
+	local.fingerprints = expirable.NewLRU[string, map[string]bool](32, nil, fingerprintTTL)
+	local.ipFingerprints = expirable.NewLRU[string, map[string]bool](32, nil, fingerprintTTL)
+	for _, store := range []*FingerprintStore{local, shared} {
+		for i := 0; i < 100; i++ {
+			store.Record(fmt.Sprint(i), "ip", "site")
+		}
+		if got := store.GetIPFingerprintCount("ip"); got != 16 {
+			t.Fatalf("unbounded cardinality: %d", got)
+		}
+		for i := 0; i < 100; i++ {
+			store.Record("shared", fmt.Sprint(i), "site")
+		}
+		if got := store.GetFingerprintIPCount("shared", "site"); got != 16 {
+			t.Fatalf("unbounded IPs: %d", got)
+		}
+	}
+	if local.fingerprints.Len() > 32 || local.ipFingerprints.Len() > 32 {
+		t.Fatal("outer store unbounded")
+	}
+	redisServer.FastForward(fingerprintTTL - time.Second)
+	shared.Record("shared", "new-ip", "site")
+	redisServer.FastForward(2 * time.Second)
+	if got := shared.GetFingerprintIPCount("shared", "site"); got != 0 {
+		t.Fatalf("traffic extended retention: %d", got)
+	}
+}

--- a/server-node/fingerprint-store.js
+++ b/server-node/fingerprint-store.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const { BoundedMap } = require('./limits');
+
+const WINDOW_MS = 15 * 60 * 1000;
+// Detectors only distinguish >5 and >10. Saturating at 16 preserves those
+// decisions without retaining every attacker-selected value.
+const MAX_MEMBERS = 16;
+
+class FingerprintStore {
+  constructor({ maxEntries = 100000, ttlMs = WINDOW_MS, now = Date.now } = {}) {
+    this.fingerprints = new BoundedMap(maxEntries);
+    this.ipFingerprints = new BoundedMap(maxEntries);
+    this.ttlMs = ttlMs;
+    this.now = now;
+  }
+
+  _get(store, key) {
+    const entry = store.get(key);
+    if (entry && entry.expiresAt <= this.now()) {
+      store.delete(key);
+      return undefined;
+    }
+    return entry;
+  }
+
+  _add(store, key, value) {
+    let entry = this._get(store, key);
+    if (!entry) {
+      entry = { values: new Set(), expiresAt: this.now() + this.ttlMs };
+      store.set(key, entry);
+    }
+    if (entry.values.size < MAX_MEMBERS) entry.values.add(value);
+  }
+
+  record(fp, ip, siteKey) {
+    const entry = this._get(this.ipFingerprints, ip);
+    // Do not allocate more fingerprint keys once this source has saturated.
+    if (entry && entry.values.size >= MAX_MEMBERS && !entry.values.has(fp)) return;
+    this._add(this.ipFingerprints, ip, fp);
+    this._add(this.fingerprints, `${siteKey}:${fp}`, ip);
+  }
+
+  getIpFpCount(ip) {
+    return this._get(this.ipFingerprints, ip)?.values.size || 0;
+  }
+
+  getFpIpCount(fp, siteKey) {
+    return this._get(this.fingerprints, `${siteKey}:${fp}`)?.values.size || 0;
+  }
+}
+
+module.exports = { FingerprintStore, WINDOW_MS, MAX_MEMBERS };

--- a/server-node/index.js
+++ b/server-node/index.js
@@ -296,8 +296,13 @@ class ScoringEngine {
           reason: `Challenge submitted before the required delay for this source (${powResult.serverElapsed}ms of ${powResult.minAgeMs}ms)`
         });
       } else {
-        powSatisfied = resolved.commitmentValid &&
-          (!powSolution.signalsHash || signals.meta?.challengeNonce === powResult.nonce);
+        powSatisfied = resolved.commitmentValid;
+      }
+      // The server-issued nonce is required even for legacy, uncommitted PoW.
+      if (powResult.valid && powResult.nonce && signals.meta?.challengeNonce !== powResult.nonce) {
+        powSatisfied = false;
+        detections.push({ category: 'bot', score: 0.9, confidence: 0.9,
+          reason: 'Challenge nonce mismatch (signals not bound to challenge)' });
       }
     } else {
       detections.push({
@@ -394,7 +399,8 @@ class ScoringEngine {
       if (ip && decoded.ip_hash !== crypto.createHash('sha256').update(ip).digest('hex').slice(0, 8)) {
         return { valid: false, reason: 'ip_mismatch' };
       }
-      if (!this.tokenStore.markUsed(sig)) return { valid: false, reason: 'token_already_used' };
+      const claim = this.tokenStore.claim(sig);
+      if (!claim.claimed) return { valid: false, reason: claim.reason };
       return {
         valid: true,
         site_key: decoded.site_key,

--- a/server-node/index.js
+++ b/server-node/index.js
@@ -6,7 +6,7 @@
  * Usage:
  *   const fcaptcha = require('@webdecoy/fcaptcha');
  *   const engine = fcaptcha.createScoringEngine({ secret: 'your-secret' });
- *   const result = engine.verify(signals, ip, siteKey, userAgent, headers, powSolution);
+ *   const result = engine.verify(signals, ip, siteKey, userAgent, headers, powSolution, signalsJson, powTiming);
  */
 
 const crypto = require('crypto');
@@ -14,6 +14,10 @@ const detection = require('./detection');
 const { ProxyTrust, networkIdentity } = require('./clientip');
 const { SuspicionLedger, computeChallengeCost, BASE_MIN_AGE_MS } = require('./suspicion');
 const { signingSecret } = require('./config');
+const { BoundedMap, BoundedSet, SiteKeyGuard } = require('./limits');
+const { FingerprintStore } = require('./fingerprint-store');
+const { TokenStore } = require('./token-store');
+const { resolveSignals } = require('./protocol');
 
 // =============================================================================
 // PoW Challenge Store (can be extended with Redis)
@@ -22,8 +26,8 @@ const { signingSecret } = require('./config');
 class PoWChallengeStore {
   constructor(options = {}) {
     this.secret = signingSecret(options.secret);
-    this.challenges = new Map();
-    this.usedSolutions = new Set();
+    this.challenges = new BoundedMap();
+    this.usedSolutions = new BoundedSet();
     this.expirationMs = options.expirationMs || 5 * 60 * 1000; // 5 minutes
   }
 
@@ -41,6 +45,7 @@ class PoWChallengeStore {
       // How long the client must hold this challenge before submitting a
       // solution. Inside the signed payload so it cannot be talked down.
       minAgeMs,
+      nonce: crypto.randomBytes(16).toString('hex'),
       prefix: `${challengeId}:${timestamp}:${difficulty}`
     };
 
@@ -64,7 +69,7 @@ class PoWChallengeStore {
     return challengeData;
   }
 
-  verify(challengeId, nonce, hash, siteKey, ip) {
+  verify(challengeId, nonce, hash, siteKey, ip, signalsHash = null) {
     const challenge = this.challenges.get(challengeId);
 
     if (!challenge) {
@@ -91,7 +96,7 @@ class PoWChallengeStore {
     }
 
     // Verify the hash
-    const input = `${challenge.prefix}:${nonce}`;
+    const input = signalsHash ? `${challenge.prefix}:${signalsHash}:${nonce}` : `${challenge.prefix}:${nonce}`;
     const expectedHash = crypto.createHash('sha256').update(input).digest('hex');
 
     if (hash !== expectedHash) {
@@ -111,6 +116,7 @@ class PoWChallengeStore {
     return {
       valid: true,
       difficulty: challenge.difficulty,
+      nonce: challenge.nonce,
       serverElapsed: Date.now() - challenge.timestamp,
       // Fall back for challenges issued before adaptive cost existed.
       minAgeMs: challenge.minAgeMs || BASE_MIN_AGE_MS
@@ -124,9 +130,6 @@ class PoWChallengeStore {
         this.challenges.delete(id);
       }
     }
-    if (this.usedSolutions.size > 10000) {
-      this.usedSolutions.clear();
-    }
   }
 }
 
@@ -136,7 +139,7 @@ class PoWChallengeStore {
 
 class RateLimiter {
   constructor() {
-    this.requests = new Map();
+    this.requests = new BoundedMap();
   }
 
   check(key, windowSeconds = 60, maxRequests = 10) {
@@ -154,42 +157,6 @@ class RateLimiter {
     timestamps.push(now);
     this.requests.set(key, timestamps);
     return [false, count + 1];
-  }
-}
-
-// =============================================================================
-// Fingerprint Store
-// =============================================================================
-
-class FingerprintStore {
-  constructor() {
-    this.fingerprints = new Map();
-    this.ipFingerprints = new Map();
-  }
-
-  record(fp, ip, siteKey) {
-    const key = `${siteKey}:${fp}`;
-
-    if (!this.fingerprints.has(key)) {
-      this.fingerprints.set(key, { count: 0, ips: new Set() });
-    }
-    const data = this.fingerprints.get(key);
-    data.count++;
-    data.ips.add(ip);
-
-    if (!this.ipFingerprints.has(ip)) {
-      this.ipFingerprints.set(ip, new Set());
-    }
-    this.ipFingerprints.get(ip).add(fp);
-  }
-
-  getIpFpCount(ip) {
-    return this.ipFingerprints.get(ip)?.size || 0;
-  }
-
-  getFpIpCount(fp, siteKey) {
-    const key = `${siteKey}:${fp}`;
-    return this.fingerprints.get(key)?.ips.size || 0;
   }
 }
 
@@ -231,6 +198,7 @@ class ScoringEngine {
     this.fingerprintStore = options.fingerprintStore || new FingerprintStore();
     this.suspicion = options.suspicion || new SuspicionLedger();
     this.weights = options.weights || WEIGHTS;
+    this.tokenStore = options.tokenStore || new TokenStore();
   }
 
   // Generate a PoW challenge
@@ -257,8 +225,16 @@ class ScoringEngine {
   }
 
   // Verify signals and return score
-  verify(signals, ip, siteKey, userAgent, headers = {}, powSolution = null) {
+  verify(signals, ip, siteKey, userAgent, headers = {}, powSolution = null, signalsJson = null, powTiming = null) {
+    const resolved = resolveSignals(signals, signalsJson, powSolution?.signalsHash);
+    signals = resolved.signals;
+    if (powTiming) {
+      signals.temporal = signals.temporal || {};
+      signals.temporal.pow = powTiming;
+    }
     const detections = [];
+    if (!resolved.commitmentValid) detections.push({ category: 'bot', score: 0.95,
+      confidence: 0.95, reason: 'Signals tampered after PoW (signalsHash mismatch)' });
     let powSatisfied = false;
 
     // Run all detection modules
@@ -288,7 +264,8 @@ class ScoringEngine {
         powSolution.nonce,
         powSolution.hash,
         siteKey,
-        ip
+        ip,
+        powSolution.signalsHash
       );
 
       if (!powResult.valid) {
@@ -299,7 +276,7 @@ class ScoringEngine {
           reason: `PoW verification failed: ${powResult.reason}`
         });
       } else if (powResult.serverElapsed < BASE_MIN_AGE_MS) {
-        powSatisfied = true;
+        powSatisfied = false;
         // Under the universal baseline nothing legitimate can have happened —
         // no human completes an interaction that fast.
         detections.push({
@@ -309,11 +286,9 @@ class ScoringEngine {
           reason: `Challenge solved too fast (${powResult.serverElapsed}ms server-side)`
         });
       } else if (powResult.serverElapsed < powResult.minAgeMs) {
-        powSatisfied = true;
-        // Between the baseline and this source's own elevated floor is weaker
-        // evidence: a client predating adaptive cost, or one served from a
-        // stale cache, does not know to wait. It contributes rather than
-        // deciding.
+        powSatisfied = false;
+        // Keep the diagnostic weaker than a baseline violation; token issuance
+        // independently requires the full advertised delay.
         detections.push({
           category: 'bot',
           score: 0.5,
@@ -321,7 +296,8 @@ class ScoringEngine {
           reason: `Challenge submitted before the required delay for this source (${powResult.serverElapsed}ms of ${powResult.minAgeMs}ms)`
         });
       } else {
-        powSatisfied = true;
+        powSatisfied = resolved.commitmentValid &&
+          (!powSolution.signalsHash || signals.meta?.challengeNonce === powResult.nonce);
       }
     } else {
       detections.push({
@@ -397,7 +373,7 @@ class ScoringEngine {
   }
 
   // Verify a previously issued token
-  verifyToken(token) {
+  verifyToken(token, ip = null) {
     try {
       const decoded = JSON.parse(Buffer.from(token, 'base64url').toString());
 
@@ -415,14 +391,21 @@ class ScoringEngine {
         return { valid: false, reason: 'invalid_signature' };
       }
 
+      if (ip && decoded.ip_hash !== crypto.createHash('sha256').update(ip).digest('hex').slice(0, 8)) {
+        return { valid: false, reason: 'ip_mismatch' };
+      }
+      if (!this.tokenStore.markUsed(sig)) return { valid: false, reason: 'token_already_used' };
       return {
         valid: true,
         site_key: decoded.site_key,
         timestamp: decoded.timestamp,
-        score: decoded.score
+        score: decoded.score,
+        hostname: decoded.hostname || '',
+        action: decoded.action || '',
+        cdata: decoded.cdata || ''
       };
     } catch (e) {
-      return { valid: false, reason: e.message };
+      return { valid: false, reason: 'invalid_token' };
     }
   }
 
@@ -497,6 +480,7 @@ class ScoringEngine {
     const ipHash = crypto.createHash('sha256').update(ip).digest('hex').slice(0, 8);
     const data = {
       site_key: siteKey,
+      jti: crypto.randomBytes(16).toString('hex'),
       timestamp: Math.floor(Date.now() / 1000),
       score: Math.round(score * 1000) / 1000,
       ip_hash: ipHash
@@ -516,6 +500,7 @@ class ScoringEngine {
 
 function createMiddleware(options = {}) {
   const engine = new ScoringEngine(options);
+  const siteKeys = SiteKeyGuard.fromEnv();
   const proxyTrust = options.trustedProxies !== undefined
     ? new ProxyTrust(options.trustedProxies)
     : ProxyTrust.fromEnv();
@@ -533,8 +518,9 @@ function createMiddleware(options = {}) {
 
     // Challenge route handler
     challengeHandler: (req, res) => {
-      const siteKey = req.query.siteKey || 'default';
+      const rawSiteKey = req.query.siteKey || 'default';
       const ip = options.getIP ? options.getIP(req) : proxyTrust.clientIP(req);
+      const siteKey = siteKeys.normalize(rawSiteKey, ip);
       const challenge = engine.generateChallenge(siteKey, ip);
 
       res.json({
@@ -542,14 +528,17 @@ function createMiddleware(options = {}) {
         prefix: challenge.prefix,
         difficulty: challenge.difficulty,
         expiresAt: challenge.expiresAt,
-        sig: challenge.sig
+        sig: challenge.sig,
+        nonce: challenge.nonce,
+        minAgeMs: challenge.minAgeMs
       });
     },
 
     // Verify route handler
     verifyHandler: (req, res) => {
-      const { siteKey, signals, powSolution } = req.body;
+      const { siteKey: rawSiteKey, signals, powSolution, signalsJson, powTiming } = req.body;
       const ip = options.getIP ? options.getIP(req) : proxyTrust.clientIP(req);
+      const siteKey = siteKeys.normalize(rawSiteKey || 'default', ip);
       const userAgent = req.headers['user-agent'] || '';
 
       const headers = {};
@@ -557,14 +546,14 @@ function createMiddleware(options = {}) {
         headers[key.toLowerCase()] = Array.isArray(value) ? value[0] : value;
       }
 
-      const result = engine.verify(signals, ip, siteKey, userAgent, headers, powSolution);
+      const result = engine.verify(signals, ip, siteKey, userAgent, headers, powSolution, signalsJson, powTiming);
       res.json(result);
     },
 
     // Token verify route handler
     tokenVerifyHandler: (req, res) => {
-      const { token } = req.body;
-      res.json(engine.verifyToken(token));
+      const { token, remoteip } = req.body;
+      res.json(engine.verifyToken(token, typeof remoteip === 'string' ? remoteip : null));
     }
   };
 }

--- a/server-node/index.test.js
+++ b/server-node/index.test.js
@@ -70,7 +70,7 @@ const cleanHeaders = {
   challenge.timestamp -= 2000;
   engine.powStore.challenges.get(challenge.id).timestamp -= 2000;
   const result = engine.verify(
-    cleanSignals,
+    { ...cleanSignals, meta: { challengeNonce: challenge.nonce } },
     '203.0.113.1',
     'site',
     'Mozilla/5.0',
@@ -88,7 +88,7 @@ const cleanHeaders = {
     scaleByReputation: false
   });
   const result = engine.verify(
-    cleanSignals, '198.51.100.1', 'site', 'Mozilla/5.0', cleanHeaders, solve(challenge)
+    { ...cleanSignals, meta: { challengeNonce: challenge.nonce } }, '198.51.100.1', 'site', 'Mozilla/5.0', cleanHeaders, solve(challenge)
   );
   assert.strictEqual(result.success, false, 'a different network must not spend the challenge');
   assert.strictEqual(result.reason, 'pow_not_satisfied');

--- a/server-node/package.json
+++ b/server-node/package.json
@@ -15,7 +15,7 @@
     "test:clientip": "node clientip.test.js",
     "test:limits": "node limits.test.js",
     "test:detection": "node detection.test.js",
-    "test": "node version.test.js && node config.test.js && node clientip.test.js && node limits.test.js && node detection.test.js && node inputforensics.test.js && node interactionmode.test.js && node exemptions.test.js && node webbotauth.test.js && node siteverify.test.js && node redis-state.test.js && node index.test.js && node --test suspicion.test.js",
+    "test": "node version.test.js && node config.test.js && node clientip.test.js && node limits.test.js && node detection.test.js && node inputforensics.test.js && node interactionmode.test.js && node exemptions.test.js && node webbotauth.test.js && node siteverify.test.js && node redis-state.test.js && node index.test.js && node --test suspicion.test.js security.test.js",
     "test:siteverify": "node siteverify.test.js",
     "test:forensics": "node inputforensics.test.js",
     "test:suspicion": "node --test suspicion.test.js"

--- a/server-node/protocol.js
+++ b/server-node/protocol.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const crypto = require('crypto');
+
+const isObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+
+function invalidRequest() {
+  return Object.assign(new Error('invalid_request'), { status: 400 });
+}
+
+// Resolve the exact bytes committed by the proof before any detector mutates
+// signals. Legacy proofs without a commitment still use the signals object.
+function resolveSignals(signals, signalsJson, signalsHash) {
+  let commitmentValid = true;
+  if (signalsHash) {
+    if (typeof signalsJson !== 'string' || typeof signalsHash !== 'string') {
+      commitmentValid = false;
+    } else {
+      commitmentValid = crypto.createHash('sha256').update(signalsJson).digest('hex') === signalsHash;
+      try { signals = JSON.parse(signalsJson); } catch { throw invalidRequest(); }
+    }
+  }
+  if (!isObject(signals)) throw invalidRequest();
+  for (const key of ['behavioral', 'environmental', 'temporal', 'meta', 'formAnalysis']) {
+    if (signals[key] != null && !isObject(signals[key])) throw invalidRequest();
+  }
+  return { signals, commitmentValid };
+}
+
+module.exports = { resolveSignals, isObject, invalidRequest };

--- a/server-node/redis-state.js
+++ b/server-node/redis-state.js
@@ -38,6 +38,16 @@ redis.call('PEXPIRE', KEYS[1], ARGV[3])
 return 1
 `;
 
+const RECORD_FINGERPRINT = `
+if redis.call('SCARD', KEYS[2]) >= 16 and redis.call('SISMEMBER', KEYS[2], ARGV[2]) == 0 then return 0 end
+if redis.call('SCARD', KEYS[1]) < 16 then redis.call('SADD', KEYS[1], ARGV[1]) end
+if redis.call('SCARD', KEYS[2]) < 16 then redis.call('SADD', KEYS[2], ARGV[2]) end
+for i = 1, 2 do
+  if redis.call('PTTL', KEYS[i]) < 0 then redis.call('PEXPIRE', KEYS[i], ARGV[3]) end
+end
+return 1
+`;
+
 class RedisState {
   constructor(url, client = null) {
     this.client = client || createClient({ url });
@@ -148,10 +158,10 @@ class RedisState {
   async recordFingerprint(fingerprint, ip, siteKey) {
     const fpKey = this.opaqueKey('fingerprint:ips', `${siteKey}|${fingerprint}`);
     const ipKey = this.opaqueKey('fingerprint:fps', ip);
-    await this.client.multi()
-      .sAdd(fpKey, this.opaqueKey('value:ip', ip)).pExpire(fpKey, DETECTION_TTL_MS)
-      .sAdd(ipKey, this.opaqueKey('value:fp', fingerprint)).pExpire(ipKey, DETECTION_TTL_MS)
-      .exec();
+    await this.client.eval(RECORD_FINGERPRINT, {
+      keys: [fpKey, ipKey],
+      arguments: [this.opaqueKey('value:ip', ip), this.opaqueKey('value:fp', fingerprint), String(DETECTION_TTL_MS)]
+    });
   }
 
   async ipFingerprintCount(ip) {

--- a/server-node/security.test.js
+++ b/server-node/security.test.js
@@ -6,6 +6,7 @@ const crypto = require('crypto');
 const { createScoringEngine, createMiddleware } = require('./index');
 const { FingerprintStore } = require('./fingerprint-store');
 const { TokenStore } = require('./token-store');
+const { reasonToErrorCode } = require('./siteverify');
 
 const signals = () => ({ behavioral: { totalPoints: 60, trajectoryLength: 400,
   microTremorScore: 0.5, velocityVariance: 0.5, approachPoints: 12,
@@ -33,6 +34,37 @@ test('full replay store fails closed and recovers after retention expires', () =
   assert.equal(store.markUsed('first'), false);
   now = 600001;
   assert.equal(store.markUsed('second'), true);
+});
+
+test('capacity errors are distinct from replays in token verification', () => {
+  const engine = createScoringEngine({ secret: 'test-secret', tokenStore: new TokenStore({ maxEntries: 1 }) });
+  const first = engine._generateToken('ip', 'site', 0.1);
+  const second = engine._generateToken('ip', 'site', 0.1);
+  assert.equal(engine.verifyToken(first).valid, true);
+  assert.deepEqual(engine.verifyToken(second), { valid: false, reason: 'token_store_full' });
+  assert.deepEqual(engine.verifyToken(first), { valid: false, reason: 'token_already_used' });
+  assert.equal(reasonToErrorCode('token_store_full'), 'internal-error');
+});
+
+test('issued nonces are required for both committed and legacy proofs', () => {
+  for (const committed of [false, true]) {
+    for (const nonceMode of ['correct', 'missing', 'wrong']) {
+      const engine = createScoringEngine({ secret: 'test-secret' });
+      const challenge = engine.generateChallenge('site', '203.0.113.1', { difficulty: 1, scaleByReputation: false });
+      engine.powStore.challenges.get(challenge.id).timestamp -= 2000;
+      const body = signals();
+      if (nonceMode !== 'missing') body.meta = { challengeNonce: nonceMode === 'correct' ? challenge.nonce : 'wrong' };
+      const raw = JSON.stringify(body);
+      const signalsHash = committed ? sha(raw) : null;
+      const prefix = committed ? `${challenge.prefix}:${signalsHash}` : challenge.prefix;
+      let nonce = 0;
+      while (!sha(`${prefix}:${nonce}`).startsWith('0')) nonce++;
+      const result = engine.verify(body, '203.0.113.1', 'site', 'Mozilla/5.0', headers,
+        { challengeId: challenge.id, nonce, hash: sha(`${prefix}:${nonce}`), signalsHash }, committed ? raw : null);
+      assert.equal(result.success, nonceMode === 'correct', `${committed}/${nonceMode}`);
+      assert.equal(result.detections.some((d) => d.reason.startsWith('Challenge nonce mismatch')), nonceMode !== 'correct');
+    }
+  }
 });
 
 test('widget-format proofs pass middleware and cannot be reused or altered', () => {
@@ -92,6 +124,7 @@ test('malformed public requests return errors while the server stays available',
   const base = `http://127.0.0.1:${server.address().port}`;
   try {
     for (const path of ['/api/verify', '/api/score']) {
+      assert.equal((await fetch(base + path)).status, 404, 'GET does not run POST validation');
       for (const body of [{}, { signals: null }, { signals: [] }, { signals: { behavioral: [] } },
         { signals: {}, signalsJson: 'null', powSolution: { signalsHash: sha('null') } }]) {
         const response = await fetch(base + path, { method: 'POST',

--- a/server-node/security.test.js
+++ b/server-node/security.test.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('crypto');
+const { createScoringEngine, createMiddleware } = require('./index');
+const { FingerprintStore } = require('./fingerprint-store');
+const { TokenStore } = require('./token-store');
+
+const signals = () => ({ behavioral: { totalPoints: 60, trajectoryLength: 400,
+  microTremorScore: 0.5, velocityVariance: 0.5, approachPoints: 12,
+  approachDirectness: 0.4, explorationRatio: 0.35, overshootCorrections: 2,
+  interactionDuration: 4200 }, environmental: { automationFlags: {} } });
+const headers = { accept: 'text/html', 'accept-language': 'en-US',
+  'accept-encoding': 'gzip, deflate, br', connection: 'keep-alive' };
+const sha = (value) => crypto.createHash('sha256').update(value).digest('hex');
+
+test('independent tokens are unique and each can only be spent once', () => {
+  const engine = createScoringEngine({ secret: 'test-secret' });
+  const first = engine._generateToken('203.0.113.1', 'site', 0.1);
+  const second = engine._generateToken('203.0.113.1', 'site', 0.1);
+  assert.notEqual(first, second);
+  assert.equal(engine.verifyToken(first).valid, true);
+  assert.equal(engine.verifyToken(first).valid, false);
+  assert.equal(engine.verifyToken(second).valid, true);
+});
+
+test('full replay store fails closed and recovers after retention expires', () => {
+  let now = 0;
+  const store = new TokenStore({ maxEntries: 1, now: () => now });
+  assert.equal(store.markUsed('first'), true);
+  assert.equal(store.markUsed('second'), false);
+  assert.equal(store.markUsed('first'), false);
+  now = 600001;
+  assert.equal(store.markUsed('second'), true);
+});
+
+test('widget-format proofs pass middleware and cannot be reused or altered', () => {
+  for (const mode of ['valid', 'mismatch', 'missing', 'early', 'elevated']) {
+    const middleware = createMiddleware({ secret: 'test-secret', trustedProxies: 'none' });
+    const engine = middleware.engine;
+    const req = { query: { siteKey: 'site' }, headers, socket: { remoteAddress: '203.0.113.1' } };
+    let challenge;
+    middleware.challengeHandler(req, { json: (value) => { challenge = value; } });
+    assert.ok(challenge.nonce);
+    assert.ok(challenge.minAgeMs >= 1500);
+    const stored = engine.powStore.challenges.get(challenge.challengeId);
+    // Exercise timing gates deterministically without sleeping or costly PoW.
+    stored.difficulty = 1;
+    stored.timestamp = Date.now() - (mode === 'early' ? 0 : 2000);
+    if (mode === 'elevated') stored.minAgeMs = 60000;
+    const body = signals();
+    body.meta = { challengeNonce: challenge.nonce };
+    const raw = JSON.stringify(body);
+    const hashOfSignals = sha(mode === 'mismatch' ? 'other payload' : raw);
+    let nonce = 0;
+    while (!sha(`${challenge.prefix}:${hashOfSignals}:${nonce}`).startsWith('0')) nonce++;
+    req.body = { siteKey: 'site', signals: body, signalsJson: mode === 'missing' ? null : raw,
+      powSolution: { challengeId: challenge.challengeId, nonce, signalsHash: hashOfSignals,
+        hash: sha(`${challenge.prefix}:${hashOfSignals}:${nonce}`) } };
+    let result;
+    middleware.verifyHandler(req, { json: (value) => { result = value; } });
+    assert.equal(result.success, mode === 'valid', `${mode}: ${JSON.stringify(result)}`);
+    if (mode === 'valid') {
+      middleware.verifyHandler(req, { json: (value) => { result = value; } });
+      assert.equal(result.success, false, 'spent proof cannot mint another token');
+    }
+  }
+});
+
+test('fingerprint churn is bounded and old suspicion expires', () => {
+  let now = 0;
+  const store = new FingerprintStore({ maxEntries: 32, now: () => now });
+  for (let i = 0; i < 10000; i++) store.record(`fp-${i}`, 'ip', 'site');
+  assert.equal(store.getIpFpCount('ip'), 16);
+  assert.equal(store.fingerprints.size, 16);
+  for (let i = 0; i < 1000; i++) store.record('shared', `ip-${i}`, 'site');
+  assert.equal(store.getFpIpCount('shared', 'site'), 16);
+  assert.ok(store.ipFingerprints.size <= 32);
+  now = 900001;
+  assert.equal(store.getFpIpCount('shared', 'site'), 0);
+  store.record('fresh', 'ip', 'site');
+  assert.equal(store.getIpFpCount('ip'), 1);
+});
+
+test('malformed public requests return errors while the server stays available', async () => {
+  process.env.FCAPTCHA_SECRET = 'test-secret';
+  process.env.REDIS_URL = '';
+  const { app } = require('./server');
+  const server = app.listen(0, '127.0.0.1');
+  await new Promise((resolve) => server.once('listening', resolve));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    for (const path of ['/api/verify', '/api/score']) {
+      for (const body of [{}, { signals: null }, { signals: [] }, { signals: { behavioral: [] } },
+        { signals: {}, signalsJson: 'null', powSolution: { signalsHash: sha('null') } }]) {
+        const response = await fetch(base + path, { method: 'POST',
+          headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) });
+        assert.equal(response.status, 400, JSON.stringify(body));
+        assert.equal((await response.json()).error, 'invalid_request');
+        assert.equal((await fetch(base + '/health')).status, 200);
+      }
+      // Exercise a rejection *inside* the async scoring handler as well as
+      // the explicit request-validation middleware above.
+      const response = await fetch(base + path, { method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ signals: { environmental: { webglInfo: { renderer: {} } } } }) });
+      assert.equal(response.status, 500);
+      assert.deepEqual(await response.json(), { error: 'internal_error' });
+      assert.equal((await fetch(base + '/health')).status, 200);
+    }
+  } finally {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -16,6 +16,9 @@ const { signingSecretFromEnv } = require('./config');
 const { SuspicionLedger, computeChallengeCost, BASE_MIN_AGE_MS } = require('./suspicion');
 const { detectInputForensics } = require('./inputforensics');
 const { RedisState } = require('./redis-state');
+const { FingerprintStore } = require('./fingerprint-store');
+const { TokenStore } = require('./token-store');
+const { resolveSignals, isObject, invalidRequest } = require('./protocol');
 const {
   HostnameAllowlist,
   IdempotencyStore,
@@ -283,7 +286,8 @@ const powChallengeStore = {
     }
 
     // Calculate server-side elapsed time (un-spoofable)
-    const serverElapsed = Date.now() - challenge.createdAt;
+    // timestamp is shared by all Redis writers; createdAt was Node-only.
+    const serverElapsed = Date.now() - challenge.timestamp;
 
     return {
       valid: true,
@@ -329,72 +333,22 @@ const rateLimiter = {
   }
 };
 
+const localFingerprintStore = new FingerprintStore();
 const fingerprintStore = {
-  fingerprints: new BoundedMap(),
-  ipFingerprints: new BoundedMap(),
-
   async record(fp, ip, siteKey) {
-    if (SHARED_STATE) {
-      try { await SHARED_STATE.recordFingerprint(fp, ip, siteKey); } catch (_) { /* reads fail closed */ }
-      return;
-    }
-    const key = `${siteKey}:${fp}`;
-
-    if (!this.fingerprints.has(key)) {
-      this.fingerprints.set(key, { count: 0, ips: new Set() });
-    }
-    const data = this.fingerprints.get(key);
-    data.count++;
-    data.ips.add(ip);
-
-    if (!this.ipFingerprints.has(ip)) {
-      this.ipFingerprints.set(ip, new Set());
-    }
-    this.ipFingerprints.get(ip).add(fp);
+    if (!SHARED_STATE) return localFingerprintStore.record(fp, ip, siteKey);
+    try { await SHARED_STATE.recordFingerprint(fp, ip, siteKey); } catch (_) { /* reads fail closed */ }
   },
-
   async getIpFpCount(ip) {
-    if (SHARED_STATE) {
-      try { return await SHARED_STATE.ipFingerprintCount(ip); } catch (_) { return 100; }
-    }
-    return this.ipFingerprints.get(ip)?.size || 0;
+    if (!SHARED_STATE) return localFingerprintStore.getIpFpCount(ip);
+    try { return await SHARED_STATE.ipFingerprintCount(ip); } catch (_) { return 100; }
   },
-
   async getFpIpCount(fp, siteKey) {
-    if (SHARED_STATE) {
-      try { return await SHARED_STATE.fingerprintIpCount(fp, siteKey); } catch (_) { return 100; }
-    }
-    const key = `${siteKey}:${fp}`;
-    return this.fingerprints.get(key)?.ips.size || 0;
+    if (!SHARED_STATE) return localFingerprintStore.getFpIpCount(fp, siteKey);
+    try { return await SHARED_STATE.fingerprintIpCount(fp, siteKey); } catch (_) { return 100; }
   }
 };
-
-// Token Store - prevents token replay attacks
-const tokenStore = {
-  usedTokens: new BoundedSet(),
-
-  // Mark a token as used (returns false if already used)
-  markUsed(tokenSig) {
-    if (this.usedTokens.has(tokenSig)) {
-      return false; // Already used
-    }
-    this.usedTokens.add(tokenSig);
-
-    // Cleanup old tokens periodically (tokens expire after 5 min anyway)
-    if (Math.random() < 0.1) this._cleanup();
-    return true;
-  },
-
-  isUsed(tokenSig) {
-    return this.usedTokens.has(tokenSig);
-  },
-
-  _cleanup() {
-    // In production with Redis, use TTL instead. In memory usedTokens is a
-    // BoundedSet, so it evicts its oldest entries rather than clearing wholesale
-    // — clearing would let an attacker who forced the threshold replay a token.
-  }
-};
+const tokenStore = new TokenStore();
 
 // Detection patterns, the pure detectors and the scoring aggregation now
 // live in engine.js, shared with the npm library entry point (index.js).
@@ -499,6 +453,7 @@ function generateToken(ip, siteKey, score, binding = {}) {
   const ipHash = crypto.createHash('sha256').update(ip).digest('hex').slice(0, 8);
   const data = {
     site_key: siteKey,
+    jti: crypto.randomBytes(16).toString('hex'),
     timestamp: Math.floor(Date.now() / 1000),
     score: Math.round(score * 1000) / 1000,
     ip_hash: ipHash,
@@ -588,24 +543,12 @@ async function verifyWebBotAuth(req) {
 async function runVerification(signals, ip, siteKey, userAgent, headers = {}, ja3Hash = null, powSolution = null, signalsJson = null, powTiming = null, preDetections = [], opts = {}) {
   const detections = Array.isArray(preDetections) ? [...preDetections] : [];
 
-  // Verify signal commitment (signalsJson hash must match powSolution.signalsHash)
   const clientSignalsHash = powSolution?.signalsHash || null;
-  if (signalsJson && clientSignalsHash) {
-    const computedHash = crypto.createHash('sha256').update(signalsJson).digest('hex');
-    if (computedHash !== clientSignalsHash) {
-      detections.push({
-        category: 'bot',
-        score: 0.95,
-        confidence: 0.95,
-        reason: 'Signals tampered after PoW (signalsHash mismatch)'
-      });
-    }
-    // Use signalsJson as the canonical signals source
-    try {
-      signals = JSON.parse(signalsJson);
-    } catch (e) {
-      // Fall back to parsed signals if signalsJson is invalid
-    }
+  const resolved = resolveSignals(signals, signalsJson, clientSignalsHash);
+  signals = resolved.signals;
+  if (!resolved.commitmentValid) {
+    detections.push({ category: 'bot', score: 0.95, confidence: 0.95,
+      reason: 'Signals tampered after PoW (signalsHash mismatch)' });
   }
 
   // Inject powTiming into signals.temporal.pow for detection functions
@@ -660,7 +603,8 @@ async function runVerification(signals, ip, siteKey, userAgent, headers = {}, ja
         // replays a solution. All ordinary things that happen to real people.
       });
     } else {
-      powSatisfied = true;
+      powSatisfied = resolved.commitmentValid &&
+        powVerification.serverElapsed >= Math.max(BASE_MIN_AGE_MS, powVerification.minAgeMs || 0);
     }
 
     // Verify challenge nonce binding
@@ -692,9 +636,8 @@ async function runVerification(signals, ip, siteKey, userAgent, headers = {}, ja
         reason: `Challenge solved too fast (${powVerification.serverElapsed}ms server-side)`
       });
     } else if (powValid && powVerification.serverElapsed < (powVerification.minAgeMs || BASE_MIN_AGE_MS)) {
-      // Between the baseline and this source's own elevated floor is weaker
-      // evidence: a client predating adaptive cost, or one served from a stale
-      // cache, does not know to wait. It contributes rather than deciding.
+      // Keep the diagnostic weaker than a baseline violation; token issuance
+      // independently requires the full advertised delay.
       detections.push({
         category: 'bot',
         score: 0.5,
@@ -870,7 +813,19 @@ function collectHeaders(req) {
   return headers;
 }
 
-app.post('/api/verify', async (req, res) => {
+const asyncRoute = (handler) => (req, res, next) => Promise.resolve().then(() => handler(req, res)).catch(next);
+
+function validateScoringRequest(req, res, next) {
+  const body = req.body;
+  if (!isObject(body) || !isObject(body.signals) ||
+      (body.siteKey != null && typeof body.siteKey !== 'string') ||
+      (body.powSolution != null && !isObject(body.powSolution)) ||
+      (body.powTiming != null && !isObject(body.powTiming))) return next(invalidRequest());
+  next();
+}
+app.use(['/api/verify', '/api/score'], validateScoringRequest);
+
+app.post('/api/verify', asyncRoute(async (req, res) => {
   const { siteKey: rawSiteKey, signals, powSolution, signalsJson, powTiming, action, cdata } = req.body;
   const ip = PROXY_TRUST.clientIP(req);
   // Bound the state an unvalidated siteKey can allocate (limits.js).
@@ -890,9 +845,9 @@ app.post('/api/verify', async (req, res) => {
   const result = await runVerification(signals, ip, siteKey, userAgent, headers, ja3Hash, powSolution, signalsJson, powTiming, webBotAuth, { peerTrusted, action, cdata, widgetInteraction: true });
   logVerdict('verify', siteKey, result);
   res.json(result);
-});
+}));
 
-app.post('/api/score', async (req, res) => {
+app.post('/api/score', asyncRoute(async (req, res) => {
   const { siteKey: rawSiteKey, signals, action, cdata, powSolution, signalsJson, powTiming } = req.body;
   const ip = PROXY_TRUST.clientIP(req);
   const siteKey = await normalizeSiteKey(rawSiteKey, ip);
@@ -924,9 +879,9 @@ app.post('/api/score', async (req, res) => {
     // needs to know which precondition failed.
     ...(result.reason ? { reason: result.reason } : {})
   });
-});
+}));
 
-app.post('/api/token/verify', async (req, res) => {
+app.post('/api/token/verify', asyncRoute(async (req, res) => {
   const { token, secret, remoteip } = req.body;
 
   // The secret gate. This endpoint is the boundary between "a browser finished a
@@ -946,7 +901,7 @@ app.post('/api/token/verify', async (req, res) => {
   // received the token. Bind only when that trusted backend explicitly supplies
   // the visitor address; using the caller socket here compares unrelated hosts.
   res.json(await verifyToken(token, typeof remoteip === 'string' && remoteip ? remoteip : null));
-});
+}));
 
 // Turnstile / reCAPTCHA / hCaptcha drop-in compatibility.
 //
@@ -968,12 +923,13 @@ async function siteverifyHandler(req, res) {
   );
 }
 
-app.post('/turnstile/v0/siteverify', siteverifyHandler);
-app.post('/recaptcha/api/siteverify', siteverifyHandler);
-app.post('/siteverify', siteverifyHandler);
+app.post('/turnstile/v0/siteverify', asyncRoute(siteverifyHandler));
+app.post('/recaptcha/api/siteverify', asyncRoute(siteverifyHandler));
+app.post('/siteverify', asyncRoute(siteverifyHandler));
 
 // PoW Challenge endpoint - client fetches this on page load
-app.get('/api/pow/challenge', async (req, res) => {
+app.get('/api/pow/challenge', asyncRoute(async (req, res) => {
+  if (req.query.siteKey != null && typeof req.query.siteKey !== 'string') throw invalidRequest();
   const ip = PROXY_TRUST.clientIP(req);
   const siteKey = await normalizeSiteKey(req.query.siteKey, ip);
 
@@ -1007,7 +963,7 @@ app.get('/api/pow/challenge', async (req, res) => {
     // wait instead of as a worse score.
     minAgeMs: challenge.minAgeMs
   });
-});
+}));
 
 // Legacy challenge endpoint for backwards compatibility
 app.get('/api/challenge', (req, res) => {
@@ -1026,7 +982,8 @@ app.use((err, req, res, next) => {
   if (err && (err.status === 413 || err.type === 'entity.too.large')) {
     return res.status(413).json({ error: 'request_too_large' });
   }
-  return next(err);
+  const status = err && err.status === 400 ? 400 : 500;
+  res.status(status).json({ error: status === 400 ? 'invalid_request' : 'internal_error' });
 });
 
 // =============================================================================
@@ -1035,15 +992,19 @@ app.use((err, req, res, next) => {
 
 async function start() {
   if (SHARED_STATE) await SHARED_STATE.connect();
-  app.listen(PORT, () => {
-    console.log(`FCaptcha server running on port ${PORT}`);
+  const server = app.listen(PORT, () => {
+    console.log(`FCaptcha server running on port ${server.address().port}`);
     console.log(`Trusted proxies: ${PROXY_TRUST.describe()}`);
     console.log(`Site keys: ${SITE_KEYS.describe()}`);
     console.log(`Shared state: ${SHARED_STATE ? 'Redis (PoW)' : 'in-memory'}`);
   });
+  return server;
 }
 
-start().catch((err) => {
-  console.error(`FCaptcha failed to start: ${err.message}`);
-  process.exit(1);
-});
+if (require.main === module) {
+  start().catch((err) => {
+    console.error(`FCaptcha failed to start: ${err.message}`);
+    process.exit(1);
+  });
+}
+module.exports = { app, start };

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -495,15 +495,15 @@ async function verifyToken(token, ip = null) {
       }
     }
 
-    let claimed;
+    let claim;
     try {
-      claimed = SHARED_STATE
-        ? await SHARED_STATE.claimToken(sig)
-        : tokenStore.markUsed(sig);
+      claim = SHARED_STATE
+        ? { claimed: await SHARED_STATE.claimToken(sig), reason: 'token_already_used' }
+        : tokenStore.claim(sig);
     } catch (_) {
       return { valid: false, reason: 'state_unavailable' };
     }
-    if (!claimed) return { valid: false, reason: 'token_already_used' };
+    if (!claim.claimed) return { valid: false, reason: claim.reason };
 
     // hostname/action/cdata default to '' so a token minted before they existed
     // still verifies and reports the same shape. The signature covers whatever
@@ -823,9 +823,8 @@ function validateScoringRequest(req, res, next) {
       (body.powTiming != null && !isObject(body.powTiming))) return next(invalidRequest());
   next();
 }
-app.use(['/api/verify', '/api/score'], validateScoringRequest);
 
-app.post('/api/verify', asyncRoute(async (req, res) => {
+app.post('/api/verify', validateScoringRequest, asyncRoute(async (req, res) => {
   const { siteKey: rawSiteKey, signals, powSolution, signalsJson, powTiming, action, cdata } = req.body;
   const ip = PROXY_TRUST.clientIP(req);
   // Bound the state an unvalidated siteKey can allocate (limits.js).
@@ -847,7 +846,7 @@ app.post('/api/verify', asyncRoute(async (req, res) => {
   res.json(result);
 }));
 
-app.post('/api/score', asyncRoute(async (req, res) => {
+app.post('/api/score', validateScoringRequest, asyncRoute(async (req, res) => {
   const { siteKey: rawSiteKey, signals, action, cdata, powSolution, signalsJson, powTiming } = req.body;
   const ip = PROXY_TRUST.clientIP(req);
   const siteKey = await normalizeSiteKey(rawSiteKey, ip);

--- a/server-node/siteverify.js
+++ b/server-node/siteverify.js
@@ -79,6 +79,7 @@ const ERROR_CODES = {
 const REASON_TO_ERROR_CODE = {
   expired: ERROR_CODES.TIMEOUT_OR_DUPLICATE,
   token_already_used: ERROR_CODES.TIMEOUT_OR_DUPLICATE,
+  token_store_full: ERROR_CODES.INTERNAL_ERROR,
   invalid_signature: ERROR_CODES.INVALID_RESPONSE,
   invalid_encoding: ERROR_CODES.INVALID_RESPONSE,
   invalid_json: ERROR_CODES.INVALID_RESPONSE,

--- a/server-node/token-store.js
+++ b/server-node/token-store.js
@@ -1,0 +1,27 @@
+'use strict';
+
+// Spent tokens must not be evicted while they can still verify. If capacity is
+// exhausted, refuse new claims rather than reopening replay of older tokens.
+class TokenStore {
+  constructor({ maxEntries = 100000, now = Date.now } = {}) {
+    this.entries = new Map();
+    this.maxEntries = maxEntries;
+    this.now = now;
+    this.nextCleanup = 0;
+  }
+
+  markUsed(signature) {
+    const now = this.now();
+    if (now >= this.nextCleanup) {
+      for (const [key, expiresAt] of this.entries) {
+        if (expiresAt <= now) this.entries.delete(key);
+      }
+      this.nextCleanup = now + 60000;
+    }
+    if (this.entries.has(signature) || this.entries.size >= this.maxEntries) return false;
+    this.entries.set(signature, now + 10 * 60 * 1000);
+    return true;
+  }
+}
+
+module.exports = { TokenStore };

--- a/server-node/token-store.js
+++ b/server-node/token-store.js
@@ -11,6 +11,10 @@ class TokenStore {
   }
 
   markUsed(signature) {
+    return this.claim(signature).claimed;
+  }
+
+  claim(signature) {
     const now = this.now();
     if (now >= this.nextCleanup) {
       for (const [key, expiresAt] of this.entries) {
@@ -18,9 +22,10 @@ class TokenStore {
       }
       this.nextCleanup = now + 60000;
     }
-    if (this.entries.has(signature) || this.entries.size >= this.maxEntries) return false;
+    if (this.entries.has(signature)) return { claimed: false, reason: 'token_already_used' };
+    if (this.entries.size >= this.maxEntries) return { claimed: false, reason: 'token_store_full' };
     this.entries.set(signature, now + 10 * 60 * 1000);
-    return true;
+    return { claimed: true };
   }
 }
 

--- a/server-python/redis_state.py
+++ b/server-python/redis_state.py
@@ -6,6 +6,8 @@ import secrets
 import time
 
 import redis
+from redis.backoff import NoBackoff
+from redis.retry import Retry
 
 PREFIX = "fcaptcha:v1:"
 POW_TTL_MS = 300_000
@@ -36,9 +38,21 @@ redis.call('SADD', KEYS[1], ARGV[1]); redis.call('PEXPIRE', KEYS[1], ARGV[3]); r
 """
 
 
+RECORD_FINGERPRINT = """
+if redis.call('SCARD', KEYS[2]) >= 16 and redis.call('SISMEMBER', KEYS[2], ARGV[2]) == 0 then return 0 end
+if redis.call('SCARD', KEYS[1]) < 16 then redis.call('SADD', KEYS[1], ARGV[1]) end
+if redis.call('SCARD', KEYS[2]) < 16 then redis.call('SADD', KEYS[2], ARGV[2]) end
+for i = 1, 2 do
+  if redis.call('PTTL', KEYS[i]) < 0 then redis.call('PEXPIRE', KEYS[i], ARGV[3]) end
+end
+return 1
+"""
+
+
 class RedisState:
     def __init__(self, url: str, client=None):
-        self.client = client or redis.Redis.from_url(url, decode_responses=True)
+        self.client = client or redis.Redis.from_url(url, decode_responses=True,
+            socket_connect_timeout=2, socket_timeout=2, retry=Retry(NoBackoff(), 0))
         self.client.ping()
 
     @staticmethod
@@ -112,9 +126,8 @@ class RedisState:
     def record_fingerprint(self, fp: str, ip: str, site_key: str) -> None:
         fp_key = self.opaque("fingerprint:ips", f"{site_key}|{fp}")
         ip_key = self.opaque("fingerprint:fps", ip)
-        with self.client.pipeline(transaction=True) as p:
-            p.sadd(fp_key, self.opaque("value:ip", ip)).pexpire(fp_key, DETECTION_TTL_MS)
-            p.sadd(ip_key, self.opaque("value:fp", fp)).pexpire(ip_key, DETECTION_TTL_MS).execute()
+        self.client.eval(RECORD_FINGERPRINT, 2, fp_key, ip_key,
+            self.opaque("value:ip", ip), self.opaque("value:fp", fp), DETECTION_TTL_MS)
 
     def ip_fingerprint_count(self, ip: str) -> int:
         return int(self.client.scard(self.opaque("fingerprint:fps", ip)))

--- a/server-python/server.py
+++ b/server-python/server.py
@@ -11,6 +11,8 @@ import hashlib
 import base64
 import json
 import re
+import secrets
+from functools import wraps
 from typing import Optional, Dict, Any, List
 from dataclasses import dataclass, field
 from enum import Enum
@@ -20,9 +22,10 @@ from fastapi import FastAPI, Request, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from pydantic import BaseModel
+from starlette.concurrency import run_in_threadpool
 
 from clientip import ProxyTrust, network_identity
-from sitekeys import SiteKeyGuard, OVERFLOW_SITE_KEY
+from sitekeys import SiteKeyGuard, OVERFLOW_SITE_KEY, BoundedLRU
 from redis_state import RedisState
 from siteverify import (
     HostnameAllowlist,
@@ -352,9 +355,27 @@ class RateLimiter:
 
 
 class FingerprintStore:
-    def __init__(self):
-        self.fingerprints: Dict[str, Dict] = {}
-        self.ip_fingerprints: Dict[str, set] = defaultdict(set)
+    MAX_MEMBERS = 16
+    TTL = 15 * 60
+
+    def __init__(self, max_entries=100_000):
+        self.fingerprints = BoundedLRU(max_entries)
+        self.ip_fingerprints = BoundedLRU(max_entries)
+
+    def _get(self, store, key):
+        entry = store.get(key)
+        if entry and entry["expires_at"] <= time.time():
+            store.delete(key)
+            return None
+        return entry
+
+    def _add(self, store, key, value):
+        entry = self._get(store, key)
+        if entry is None:
+            entry = {"values": set(), "expires_at": time.time() + self.TTL}
+            store.set(key, entry)
+        if len(entry["values"]) < self.MAX_MEMBERS:
+            entry["values"].add(value)
 
     def record(self, fp: str, ip: str, site_key: str):
         if SHARED_STATE:
@@ -363,12 +384,11 @@ class FingerprintStore:
             except Exception:
                 pass
             return
-        key = f"{site_key}:{fp}"
-        if key not in self.fingerprints:
-            self.fingerprints[key] = {"count": 0, "ips": set()}
-        self.fingerprints[key]["count"] += 1
-        self.fingerprints[key]["ips"].add(ip)
-        self.ip_fingerprints[ip].add(fp)
+        entry = self._get(self.ip_fingerprints, ip)
+        if entry and len(entry["values"]) >= self.MAX_MEMBERS and fp not in entry["values"]:
+            return
+        self._add(self.ip_fingerprints, ip, fp)
+        self._add(self.fingerprints, f"{site_key}:{fp}", ip)
 
     def get_ip_fp_count(self, ip: str) -> int:
         if SHARED_STATE:
@@ -376,7 +396,8 @@ class FingerprintStore:
                 return SHARED_STATE.ip_fingerprint_count(ip)
             except Exception:
                 return 100
-        return len(self.ip_fingerprints.get(ip, set()))
+        entry = self._get(self.ip_fingerprints, ip)
+        return len(entry["values"]) if entry else 0
 
     def get_fp_ip_count(self, fp: str, site_key: str) -> int:
         if SHARED_STATE:
@@ -384,8 +405,8 @@ class FingerprintStore:
                 return SHARED_STATE.fingerprint_ip_count(fp, site_key)
             except Exception:
                 return 100
-        key = f"{site_key}:{fp}"
-        return len(self.fingerprints.get(key, {}).get("ips", set()))
+        entry = self._get(self.fingerprints, f"{site_key}:{fp}")
+        return len(entry["values"]) if entry else 0
 
 
 class PoWChallengeStore:
@@ -1609,6 +1630,7 @@ def generate_token(
     ip_hash = hashlib.sha256(ip.encode()).hexdigest()[:8]
     data = {
         "site_key": site_key,
+        "jti": secrets.token_hex(16),
         "timestamp": int(time.time()),
         "score": round(score, 3),
         "ip_hash": ip_hash,
@@ -1705,20 +1727,20 @@ def run_verification(
 
     detections = []
 
-    # Verify signal commitment (signalsJson hash must match powSolution.signalsHash)
     client_signals_hash = pow_solution.signalsHash if pow_solution else None
-    if signals_json and client_signals_hash:
-        computed_hash = hashlib.sha256(signals_json.encode()).hexdigest()
-        if computed_hash != client_signals_hash:
-            detections.append(Detection(
-                ThreatCategory.BOT, 0.95, 0.95,
-                "Signals tampered after PoW (signalsHash mismatch)"
-            ))
-        # Use signalsJson as the canonical signals source
-        try:
-            signals = json.loads(signals_json)
-        except json.JSONDecodeError:
-            pass  # Fall back to parsed signals
+    commitment_valid = True
+    if client_signals_hash:
+        commitment_valid = isinstance(signals_json, str) and hashlib.sha256(signals_json.encode()).hexdigest() == client_signals_hash
+        if signals_json:
+            try:
+                signals = json.loads(signals_json)
+            except (ValueError, TypeError):
+                raise HTTPException(status_code=400, detail="Invalid signals")
+        if not commitment_valid:
+            detections.append(Detection(ThreatCategory.BOT, 0.95, 0.95,
+                "Signals tampered after PoW (signalsHash mismatch)"))
+    if not isinstance(signals, dict):
+        raise HTTPException(status_code=400, detail="Invalid signals")
 
     # Inject powTiming into signals.temporal.pow for detection functions
     if pow_timing:
@@ -1764,7 +1786,7 @@ def run_verification(
                 # the outstanding ones, and a double-click replays a solution.
             ))
         else:
-            pow_satisfied = True
+            pow_satisfied = commitment_valid and pow_result["serverElapsed"] >= max(BASE_MIN_AGE_MS, pow_result.get("minAgeMs") or BASE_MIN_AGE_MS)
 
         # Verify challenge nonce binding
         if pow_result["valid"] and pow_result.get("nonce"):
@@ -1793,10 +1815,8 @@ def run_verification(
                     f"Challenge solved too fast ({elapsed}ms server-side)"
                 ))
             elif elapsed < min_age:
-                # Between the baseline and this source's own elevated floor is
-                # weaker evidence: a client predating adaptive cost, or one
-                # served from a stale cache, does not know to wait. It
-                # contributes rather than deciding.
+                # Keep the diagnostic weaker than a baseline violation; token
+                # issuance independently requires the full advertised delay.
                 detections.append(Detection(
                     ThreatCategory.BOT, 0.5, 0.5,
                     f"Challenge submitted before the required delay for this "
@@ -1988,8 +2008,22 @@ def collect_headers(request: Request) -> Dict[str, str]:
     }
 
 
+async def run_stateful(fn, *args, **kwargs):
+    if SHARED_STATE:
+        return await run_in_threadpool(fn, *args, **kwargs)
+    return fn(*args, **kwargs)
+
+
+def stateful_route(fn):
+    @wraps(fn)
+    async def route(*args, **kwargs):
+        return await run_stateful(fn, *args, **kwargs)
+    return route
+
+
 @app.post("/api/verify")
-async def verify(req: VerifyRequest, request: Request):
+@stateful_route
+def verify(req: VerifyRequest, request: Request):
     ip = PROXY_TRUST.client_ip(request)
     # Bound the state an unvalidated site_key can allocate (sitekeys.py).
     req.siteKey = normalize_site_key(req.siteKey, ip)
@@ -2007,7 +2041,8 @@ async def verify(req: VerifyRequest, request: Request):
 
 
 @app.post("/api/score")
-async def score(req: ScoreRequest, request: Request):
+@stateful_route
+def score(req: ScoreRequest, request: Request):
     ip = PROXY_TRUST.client_ip(request)
     # Bound the state an unvalidated site_key can allocate (sitekeys.py).
     req.siteKey = normalize_site_key(req.siteKey, ip)
@@ -2034,7 +2069,8 @@ async def score(req: ScoreRequest, request: Request):
 
 
 @app.post("/api/token/verify")
-async def token_verify(req: TokenVerifyRequest, request: Request):
+@stateful_route
+def token_verify(req: TokenVerifyRequest, request: Request):
     # The secret gate. This endpoint is the boundary between "a browser finished
     # a challenge" and "my backend believes it", so it is server-to-server and
     # needs a credential - without one, anyone who can reach the host can spend a
@@ -2078,7 +2114,7 @@ async def _read_siteverify_body(request: Request) -> Any:
 
 async def _siteverify_route(request: Request):
     body = await _read_siteverify_body(request)
-    return siteverify(
+    return await run_stateful(siteverify,
         body=body,
         # Bind to this server's token store, so replay state is shared with the
         # native endpoint rather than kept in a parallel universe.
@@ -2095,7 +2131,8 @@ app.post("/siteverify")(_siteverify_route)
 
 
 @app.get("/api/pow/challenge")
-async def pow_challenge(request: Request, siteKey: str = "default"):
+@stateful_route
+def pow_challenge(request: Request, siteKey: str = "default"):
     from detection import is_datacenter_ip
 
     ip = PROXY_TRUST.client_ip(request)
@@ -2145,4 +2182,5 @@ if __name__ == "__main__":
     #
     # Running uvicorn directly? Pass --no-proxy-headers. Under gunicorn, set
     # forwarded_allow_ips to nothing. See INSTALLATION.md.
-    uvicorn.run(app, host="0.0.0.0", port=port, proxy_headers=False)
+    uvicorn.run(app, host="0.0.0.0", port=port, proxy_headers=False,
+        access_log=_env_flag("FCAPTCHA_LOG_ACCESS"))

--- a/server-python/test_security.py
+++ b/server-python/test_security.py
@@ -1,0 +1,96 @@
+import asyncio
+import hashlib
+import json
+import os
+import runpy
+from pathlib import Path
+import threading
+import unittest
+from unittest.mock import patch
+
+os.environ.setdefault("FCAPTCHA_SECRET", "security-test-secret")
+import server
+
+
+def clean_signals():
+    return {"behavioral": {"totalPoints": 60, "trajectoryLength": 400,
+        "microTremorScore": 0.5, "velocityVariance": 0.5, "approachPoints": 12,
+        "approachDirectness": 0.4, "explorationRatio": 0.35, "overshootCorrections": 2,
+        "interactionDuration": 4200}, "environmental": {"automationFlags": {}},
+        "meta": {"challengeNonce": "binding"}}
+
+
+class SecurityTests(unittest.TestCase):
+    def test_launcher_access_logging_is_opt_in(self):
+        for flag, expected in (("", False), ("1", True)):
+            with patch.dict(os.environ, {"REDIS_URL": "", "FCAPTCHA_LOG_ACCESS": flag}), patch("uvicorn.run") as run:
+                runpy.run_path(str(Path(server.__file__)), run_name="__main__")
+                self.assertIs(run.call_args.kwargs["access_log"], expected)
+
+    def test_independent_tokens_and_replay(self):
+        with patch.object(server.time, "time", return_value=1800000000):
+            a = server.generate_token("ip", "site", 0.1)
+            b = server.generate_token("ip", "site", 0.1)
+            self.assertNotEqual(a, b)
+            self.assertTrue(server.verify_token(a)["valid"])
+            self.assertFalse(server.verify_token(a)["valid"])
+            self.assertTrue(server.verify_token(b)["valid"])
+
+    def test_commitment_and_timing_gate_even_with_clean_signals(self):
+        for mode in ("valid", "mismatch", "missing", "early", "elevated"):
+            with self.subTest(mode=mode):
+                signals = clean_signals()
+                raw = json.dumps(signals)
+                digest = hashlib.sha256(("other payload" if mode == "mismatch" else raw).encode()).hexdigest()
+                proof = server.PoWSolution(challengeId="id", nonce=1, hash="hash", signalsHash=digest)
+                verified = {"valid": True, "nonce": "binding", "difficulty": 4,
+                    "serverElapsed": 1 if mode == "early" else 2000,
+                    "minAgeMs": 60000 if mode == "elevated" else 1500}
+                with patch.object(server.pow_store, "verify", return_value=verified):
+                    result = server.run_verification(signals, "203.0.113.1", mode,
+                        "Mozilla/5.0", {"accept": "text/html", "accept-language": "en-US",
+                        "accept-encoding": "gzip", "connection": "keep-alive"},
+                        pow_solution=proof, signals_json=None if mode == "missing" else raw)
+                self.assertEqual(result["success"], mode == "valid", result)
+                if mode != "valid":
+                    self.assertIsNone(result["token"])
+
+    def test_fingerprint_bounds_and_expiry(self):
+        with patch.object(server.time, "time", return_value=1000) as now:
+            store = server.FingerprintStore(max_entries=32)
+            for i in range(10000):
+                store.record(str(i), "ip", "site")
+            self.assertEqual(store.get_ip_fp_count("ip"), 16)
+            self.assertEqual(len(store.fingerprints), 16)
+            for i in range(100):
+                store.record("shared", str(i), "site")
+            self.assertEqual(store.get_fp_ip_count("shared", "site"), 16)
+            self.assertLessEqual(len(store.ip_fingerprints), 32)
+            now.return_value = 2000
+            self.assertEqual(store.get_fp_ip_count("shared", "site"), 0)
+
+    def test_redis_work_does_not_block_health_or_event_loop(self):
+        async def run():
+            started = threading.Event()
+            release = threading.Event()
+
+            def blocking_state_call():
+                started.set()
+                if not release.wait(2):
+                    raise AssertionError("event loop blocked behind Redis work")
+                return "done"
+
+            with patch.object(server, "SHARED_STATE", object()):
+                task = asyncio.create_task(server.run_stateful(blocking_state_call))
+                try:
+                    while not started.is_set():
+                        await asyncio.sleep(0.001)
+                    self.assertEqual((await server.health())["status"], "ok")
+                finally:
+                    release.set()
+                self.assertEqual(await task, "done")
+        asyncio.run(run())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/browser/tests/session-lifecycle.spec.ts
+++ b/test/browser/tests/session-lifecycle.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect, Page } from '@playwright/test';
+
+async function session(page: Page) {
+  await page.goto('/health');
+  await page.addScriptTag({ url: '/fcaptcha.js' });
+  await page.evaluate(() => {
+    const w = window as any;
+    w.FCaptcha.configure({ serverUrl: location.origin });
+    const s = w.session = w.FCaptcha.invisible({ siteKey: 'lifecycle', autoScore: false, minCollectionTime: 0 });
+    // Test the real network/PoW lifecycle without webdriver detection deciding
+    // the verdict or asynchronous environmental probes obscuring the failure.
+    s.environmental.collect = () => ({ automationFlags: {} });
+    s.environmental.collectAsync = async () => ({});
+    s.environmental.measureRAFConsistency = async () => ({});
+    s.behavioral.analyze = () => ({ totalPoints: 60, trajectoryLength: 400,
+      microTremorScore: 0.5, velocityVariance: 0.5, approachPoints: 12,
+      approachDirectness: 0.4, explorationRatio: 0.35, overshootCorrections: 2,
+      interactionDuration: 4200 });
+    s.temporal.collect = () => ({});
+  });
+  await page.waitForFunction(() => !!(window as any).session.powManager.challenge);
+}
+
+test('repeated and concurrent actions each receive a fresh usable challenge', async ({ page }) => {
+  await session(page);
+  const challengeIds: string[] = [];
+  page.on('request', (req) => {
+    if (req.url().endsWith('/api/score')) challengeIds.push(req.postDataJSON().powSolution.challengeId);
+  });
+  const results = await page.evaluate(async () => {
+    const s = (window as any).session;
+    return [await s.execute('first'), ...await Promise.all([s.execute('second'), s.execute('third')])];
+  });
+  expect(results.map((r) => r.success)).toEqual([true, true, true]);
+  expect(new Set(challengeIds).size).toBe(3);
+  expect(new Set(results.map((r) => r.token)).size).toBe(3);
+});
+
+test('expiry refresh binds signals to the replacement challenge', async ({ page }) => {
+  await session(page);
+  const old = await page.evaluate(() => {
+    const c = (window as any).session.powManager.challenge;
+    c.expiresAt = Date.now() - 1;
+    return { id: c.challengeId, nonce: c.nonce };
+  });
+  const submission = page.waitForRequest((req) => req.url().endsWith('/api/score'));
+  const result = await page.evaluate(() => (window as any).session.execute('expired'));
+  const body = (await submission).postDataJSON();
+  expect(body.powSolution.challengeId).not.toBe(old.id);
+  expect(body.signals.meta.challengeNonce).not.toBe(old.nonce);
+  expect(result.success).toBe(true);
+});
+
+test('a persistent session can retry after its solver fails', async ({ page }) => {
+  await session(page);
+  const result = await page.evaluate(async () => {
+    const s = (window as any).session;
+    const create = s.powManager._createWorker;
+    s.powManager._createWorker = () => { throw new Error('worker failed'); };
+    let rejected = false;
+    try { await s.execute('first'); } catch { rejected = true; }
+    s.powManager._createWorker = create;
+    return { rejected, retry: (await s.execute('retry')).success };
+  });
+  expect(result).toEqual({ rejected: true, retry: true });
+});
+
+test('destroy removes retained sessions, sensors, and form handlers', async ({ page }) => {
+  await page.goto('/health');
+  await page.addScriptTag({ url: '/fcaptcha.js' });
+  const result = await page.evaluate(() => {
+    const api = (window as any).FCaptcha;
+    const form = document.createElement('form');
+    document.body.appendChild(form);
+    const sessions = Array.from({ length: 10 }, () => api.invisible({ autoScore: true }));
+    for (const s of sessions) s.destroy();
+    const event = new Event('submit', { bubbles: true, cancelable: true });
+    form.dispatchEvent(event);
+    window.dispatchEvent(new Event('devicemotion'));
+    window.dispatchEvent(new Event('deviceorientation'));
+    return { retained: api.widgets.size, intercepted: event.defaultPrevented,
+      samples: sessions.map((s) => s.sensor.motionEvents.length + s.sensor.orientationEvents.length) };
+  });
+  expect(result).toEqual({ retained: 0, intercepted: false, samples: Array(10).fill(0) });
+});
+
+test('public execute cleans up when the worker cannot start', async ({ page }) => {
+  await page.goto('/health');
+  await page.evaluate(() => {
+    const w = window as any;
+    w.sensors = new Set();
+    const add = window.addEventListener.bind(window);
+    const remove = window.removeEventListener.bind(window);
+    window.addEventListener = ((name: string, fn: any, options: any) => {
+      if (name === 'devicemotion' || name === 'deviceorientation') w.sensors.add(fn);
+      add(name, fn, options);
+    }) as any;
+    window.removeEventListener = ((name: string, fn: any, options: any) => {
+      if (name === 'devicemotion' || name === 'deviceorientation') w.sensors.delete(fn);
+      remove(name, fn, options);
+    }) as any;
+    w.Worker = class { constructor() { throw new Error('worker disabled'); } };
+  });
+  await page.addScriptTag({ url: '/fcaptcha.js' });
+  const result = await page.evaluate(async () => {
+    const w = window as any;
+    let rejected = false;
+    try { await w.FCaptcha.execute('cleanup', { minTime: 1 }); } catch { rejected = true; }
+    return { rejected, sensors: w.sensors.size };
+  });
+  expect(result).toEqual({ rejected: true, sensors: 0 });
+});
+
+test('destroying one widget leaves another widget usable', async ({ page }) => {
+  await page.goto('/health');
+  await page.addScriptTag({ url: '/fcaptcha.js' });
+  expect(await page.evaluate(() => {
+    const api = (window as any).FCaptcha;
+    const first = document.createElement('div');
+    const second = document.createElement('div');
+    document.body.append(first, second);
+    const a = api.render(first, { siteKey: 'one' });
+    const b = api.render(second, { siteKey: 'two' });
+    const separate = api.widgets.get(a).powManager !== api.widgets.get(b).powManager;
+    api.destroy(a);
+    const result = { separate, retained: api.widgets.size, removed: first.childElementCount,
+      remaining: !!second.querySelector('[role=checkbox]') };
+    api.destroy(b);
+    return result;
+  })).toEqual({ separate: true, retained: 1, removed: 0, remaining: true });
+});

--- a/test/conformance.js
+++ b/test/conformance.js
@@ -153,7 +153,10 @@ async function run() {
     'X-Real-IP': '203.0.113.40',
   };
   const committed = await buildVerifyBody(SERVER, 'commitment-test', {}, committedHeaders);
-  committed.body.signalsJson = JSON.stringify({ meta: { challengeNonce: 'tampered' } });
+  // Keep the real challenge nonce: this must fail solely on commitment integrity.
+  const changed = JSON.parse(committed.body.signalsJson);
+  changed.uncommittedField = true;
+  committed.body.signalsJson = JSON.stringify(changed);
   const tampered = await request('/api/verify', { headers: committedHeaders, body: committed.body });
   ok(
     tampered.json?.success === false && !tampered.json?.token &&


### PR DESCRIPTION
## What and why

Malformed requests could terminate the Node server, npm library tokens could be replayed, and mismatched signal commitments or skipped challenge delays could still mint tokens. This change makes those verification prerequisites independent of the weighted bot score and fixes the associated performance and browser lifecycle issues across the supported implementations.

- Catch async route failures and validate Node scoring requests; give independently issued tokens random signed IDs and enforce single use in the npm library.
- Accept the current widget proof format in npm middleware, require the issued nonce for both legacy and committed proofs, enforce signal commitments and challenge minimum ages, and use the shared timestamp field when Node verifies Redis challenges issued by Go or Python.
- Align Go commitment-failure scoring and proof consumption with Node/Python, distinguish full Node token stores from token replay, and scope request validation to scoring POST routes.
- Bound fingerprint buckets and their member sets, expire their scoring state, and use atomic, capped Redis fingerprint updates.
- Offload Python Redis request work from the event loop and configure connection/operation timeouts without retries.
- Refresh challenges before capturing their nonce, serialize repeated invisible executions, avoid reusing spent form tokens, and release sensors, listeners, workers, timers, and retained widget registrations during cleanup.
- Make Go and Python launcher access logs opt-in, document the settings and cleanup API, and add mixed-runtime Redis CI jobs.

## Validation

- Node unit and new security regression tests passed, including nonce omission/mismatch, token-store capacity diagnostics, and GET routing.
- Go `go vet ./...` and `go test -race ./...` passed, including valid/tampered commitment requests through both HTTP scoring endpoints.
- Python unit suite and new security/access-log regressions passed.
- Browser suite plus targeted lifecycle regressions passed: 47 distinct tests.
- End-to-end detection suite: 111 passed, 0 failed.
- API conformance: 12 checks passed for each of Node, Go, and Python.
- Cross-runtime Redis conformance passed for Node → Python, Python → Go, and Go → Node against a local miniredis server. The CI matrix exercises production images against Redis 7.
- False-positive benchmark gate passed: 201 samples, no replay errors, 0/126 labeled human samples flagged, and 73/75 agent samples above the detection threshold. Existing corpus exemptions and the declared-crawler/source-patched class warnings remain; these are corpus results, not population-wide accuracy claims.
- `git diff --check` passed.

## Checklist

- [x] Shared verification and fingerprint changes applied to Go, Python, and Node.
- [x] Server unit tests and Go race checks pass.
- [x] End-to-end detection suite passes.
- [x] Benchmark false-positive gate passes.
- [x] No new detector scoring thresholds or weights introduced; storage saturation stays above the existing cardinality thresholds.
- [ ] Paired before/after human-persona score comparison was not run. The current benchmark human panel has zero flagged samples.

## Verification classification

These are **precondition** fixes: a bad signal commitment or unmet minimum challenge age prevents token issuance regardless of the weighted score. No new detector is added.

## Compatibility notes

- Custom clients must honor the advertised `minAgeMs` and provide the matching serialized signals when submitting a committed proof. Deploy the updated widget with the server fixes.
- npm library tokens now verify only once; retries must follow the integrating application's retry/idempotency policy. Invisible form protection performs a fresh verification on every submission.
- Direct npm `engine.verify()` calls throw an error with `status: 400` for malformed signals. A full local Node replay store returns `token_store_full`, mapped to Siteverify `internal-error`.
- Fingerprint cardinality uses fixed 15-minute windows capped at 16 members per bucket.
- These behavior changes are documented in the changelog’s Unreleased section.
- Go and Python launcher access logs now require `FCAPTCHA_LOG_ACCESS=1`. Verdict logging retains its separate setting.
- Importing `server-node/server.js` now exports `{ app, start }` without starting a listener; programmatic consumers should call `start()`. Running `node server.js` or `npm start` continues to start the server.
