### PR TITLE
Lower the corroboration bar to 0.4; console-attach probe no longer counts as a view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ the project uses [Semantic Versioning](https://semver.org/) — with the caveat
 that pre-2.0 it has used minor bumps for behaviour changes that a stricter
 reading would call major. Read the **Breaking** entries rather than the number.
 
+## [Unreleased]
+
+### Detection
+- Lower the behavioural corroboration bar from 0.5 to 0.4. Two independent
+  behavioural categories at 0.4 now floor the score at 0.6 and withhold the
+  token. The DevTools console-attach probe no longer counts as one of the
+  agreeing views, so a developer with the console open contributes that one
+  signal and nothing more. On the bench corpus no human sample reaches two
+  agreeing categories at 0.4, the agent catch rate is unchanged from 0.5, and
+  the false-positive gate passes. Applied to Go, Node, and Python.
+
 ## [1.35.0] — 2026-09-09
 
 ### Security and fixes

--- a/bench/tools/compare-aggregation.js
+++ b/bench/tools/compare-aggregation.js
@@ -176,6 +176,25 @@ const SCHEMES = {
     return agreeing >= 2 ? Math.max(base, 0.6) : base;
   },
 
+  /**
+   * The shipped rule since the agreement bar moved to 0.4: two behavioural
+   * categories at 0.4 floor at 0.6, and the DevTools console-attach probe does
+   * not count as a view — a developer with the console open produces it, so it
+   * must not be the second half of a corroboration.
+   */
+  corroborationFloor2AgreeAt04: (dets) => {
+    const cats = {};
+    for (const [c, ds] of Object.entries(byCategory(dets))) cats[c] = categoryNoisyOr(ds);
+    const base = finalScore(cats);
+    if (dets.some(isSelfDeclared)) return Math.max(base, 0.9);
+    const views = {};
+    const corroborating = dets.filter((d) => !/console consumer attached/.test(d.reason || ''));
+    for (const [c, ds] of Object.entries(byCategory(corroborating))) views[c] = categoryNoisyOr(ds);
+    const BEHAV = ['vision_ai', 'behavioral', 'automation', 'cdp'];
+    const agreeing = BEHAV.filter((c) => (views[c] || 0) >= 0.4).length;
+    return agreeing >= 2 ? Math.max(base, 0.6) : base;
+  },
+
   /** Rebalanced weights plus the 2-of-4 corroboration floor. */
   rebalancedPlusCorroboration2: (dets) => {
     const W = { ...WEIGHTS,

--- a/bench/tools/sweep-corroboration.js
+++ b/bench/tools/sweep-corroboration.js
@@ -38,6 +38,13 @@ const BEHAVIOURAL = ['vision_ai', 'behavioral', 'automation', 'cdp'];
 
 const SELF_DECLARED = [/^WebDriver detected$/, /^CDP automation detected/];
 const isSelfDeclared = (d) => SELF_DECLARED.some((re) => re.test(d.reason || ''));
+// Signals a developer's own tooling produces (DevTools open trips the
+// console-attach probe). They score, but cannot be one of the agreeing views —
+// the engine marks them nonCorroborating; the pattern covers older servers.
+const NON_CORROBORATING = [/console consumer attached/];
+const isNonCorroborating = (d) =>
+  d.nonCorroborating === true || NON_CORROBORATING.some((re) => re.test(d.reason || ''));
+const corroboratingOnly = (detections) => detections.filter((d) => !isNonCorroborating(d));
 
 function categoryNoisyOr(dets) {
   let survive = 1;
@@ -61,13 +68,14 @@ function score(detections, agreeAt, minAgree, floor) {
     Object.entries(WEIGHTS).reduce((t, [c, w]) => t + (cats[c] || 0) * w, 0)
   );
   if (detections.some(isSelfDeclared)) return Math.max(base, 0.9);
-  const agreeing = BEHAVIOURAL.filter((c) => (cats[c] || 0) >= agreeAt).length;
+  const views = categoriesOf(corroboratingOnly(detections));
+  const agreeing = BEHAVIOURAL.filter((c) => (views[c] || 0) >= agreeAt).length;
   return agreeing >= minAgree ? Math.max(base, floor) : base;
 }
 
 /** How many behavioural categories agree, for diagnosing where a rule fires. */
 const agreementCount = (detections, agreeAt) =>
-  BEHAVIOURAL.filter((c) => (categoriesOf(detections)[c] || 0) >= agreeAt).length;
+  BEHAVIOURAL.filter((c) => (categoriesOf(corroboratingOnly(detections))[c] || 0) >= agreeAt).length;
 
 async function main() {
   const i = process.argv.indexOf('--derive');

--- a/server-go/corroboration_test.go
+++ b/server-go/corroboration_test.go
@@ -1,10 +1,24 @@
 package main
 
-import "testing"
+import (
+	"math"
+	"strings"
+	"testing"
+)
 
 // The behavioural corroboration floor. See scoring.go for the measurement that
 // chose its constants; these pin the behaviour and the invariants that keep it
 // honest.
+
+// views builds one detection per category at exactly the given strength, so
+// each category's noisy-OR score is the number written here.
+func views(cats map[string]float64) []DetectionResult {
+	out := make([]DetectionResult, 0, len(cats))
+	for cat, strength := range cats {
+		out = append(out, DetectionResult{Category: ThreatCategory(cat), Score: strength, Confidence: 1})
+	}
+	return out
+}
 
 func TestCorroborationFiresOnTwoAgreeingCategories(t *testing.T) {
 	// The shape of the source-patched corpus sample: strong behavioural
@@ -16,7 +30,7 @@ func TestCorroborationFiresOnTwoAgreeingCategories(t *testing.T) {
 	}
 	base := 0.234 // what the weighted sum produces for exactly this input
 
-	got := applyCorroborationFloor(base, cats)
+	got := applyCorroborationFloor(base, views(cats))
 	if got < corroborationFloor {
 		t.Errorf("two agreeing categories should floor at %v, got %v", corroborationFloor, got)
 	}
@@ -33,7 +47,7 @@ func TestCorroborationIgnoresASingleStrongCategory(t *testing.T) {
 	// guard against the rule becoming "any behavioural detection blocks".
 	for _, cat := range behaviouralCategories {
 		cats := map[string]float64{string(cat): 1.0}
-		if got := applyCorroborationFloor(0.2, cats); got != 0.2 {
+		if got := applyCorroborationFloor(0.2, views(cats)); got != 0.2 {
 			t.Errorf("%s alone at 1.0 must not floor, got %v", cat, got)
 		}
 	}
@@ -48,7 +62,7 @@ func TestCorroborationIgnoresNonBehaviouralCategories(t *testing.T) {
 		string(CategoryDatacenter):  1.0,
 		string(CategoryBot):         1.0,
 	}
-	if got := applyCorroborationFloor(0.3, cats); got != 0.3 {
+	if got := applyCorroborationFloor(0.3, views(cats)); got != 0.3 {
 		t.Errorf("non-behavioural categories must not corroborate, got %v", got)
 	}
 }
@@ -60,25 +74,115 @@ func TestCorroborationNeverLowersAScore(t *testing.T) {
 		string(CategoryVisionAI):   0.9,
 		string(CategoryBehavioral): 0.9,
 	}
-	if got := applyCorroborationFloor(0.95, cats); got != 0.95 {
+	if got := applyCorroborationFloor(0.95, views(cats)); got != 0.95 {
 		t.Errorf("floor lowered a higher score to %v", got)
 	}
 }
 
 func TestCorroborationRespectsTheAgreementThreshold(t *testing.T) {
-	just_under := corroborationAgreeAt - 0.01
+	justUnder := corroborationAgreeAt - 0.01
 	cats := map[string]float64{
-		string(CategoryVisionAI):   just_under,
-		string(CategoryBehavioral): just_under,
+		string(CategoryVisionAI):   justUnder,
+		string(CategoryBehavioral): justUnder,
 	}
-	if got := applyCorroborationFloor(0.2, cats); got != 0.2 {
+	if got := applyCorroborationFloor(0.2, views(cats)); got != 0.2 {
 		t.Errorf("categories below the threshold must not agree, got %v", got)
 	}
 
 	cats[string(CategoryVisionAI)] = corroborationAgreeAt
 	cats[string(CategoryBehavioral)] = corroborationAgreeAt
-	if got := applyCorroborationFloor(0.2, cats); got != corroborationFloor {
+	if got := applyCorroborationFloor(0.2, views(cats)); got != corroborationFloor {
 		t.Errorf("categories at the threshold should agree, got %v", got)
+	}
+}
+
+// A signal that a developer's own tooling produces cannot be one of the two
+// agreeing views, however it scores. The console-attach probe is the case in
+// point: DevTools open trips it, so counting it would turn "developer with a
+// slightly odd click" into a block.
+func TestCorroborationIgnoresNonCorroboratingDetections(t *testing.T) {
+	consoleAttached := DetectionResult{Category: CategoryCDP, Score: 0.6, Confidence: 1,
+		Reason: "console attached", NonCorroborating: true}
+	movement := DetectionResult{Category: CategoryBehavioral, Score: corroborationAgreeAt, Confidence: 1}
+
+	if got := applyCorroborationFloor(0.2, []DetectionResult{consoleAttached, movement}); got != 0.2 {
+		t.Errorf("a non-corroborating signal must not be the second view, got %v", got)
+	}
+
+	// The same evidence from a signal that is an independent view does floor:
+	// the exclusion is about provenance, not strength.
+	independent := consoleAttached
+	independent.NonCorroborating = false
+	if got := applyCorroborationFloor(0.2, []DetectionResult{independent, movement}); got != corroborationFloor {
+		t.Errorf("an independent cdp view at %v should floor, got %v", independent.Score, got)
+	}
+}
+
+// Excluded from agreement, not from the score: the category noisy-OR and the
+// weighted sum still see a non-corroborating detection.
+func TestNonCorroboratingDetectionsStillScore(t *testing.T) {
+	e := NewScoringEngine("test-secret")
+	marked := []DetectionResult{{Category: CategoryCDP, Score: 0.6, Confidence: 0.5, NonCorroborating: true}}
+	if got := e.calculateCategoryScores(marked)[string(CategoryCDP)]; math.Abs(got-0.3) > 1e-9 {
+		t.Errorf("non-corroborating detection should still score its category at 0.3, got %v", got)
+	}
+}
+
+// The mark has to be on the literal the engine emits, or the exclusion above
+// protects nobody.
+func TestConsoleAttachedIsNonCorroborating(t *testing.T) {
+	e := NewScoringEngine("test-secret")
+	got := e.detectCDP(map[string]interface{}{
+		"behavioral":    map[string]interface{}{"touchEvents": 0.0},
+		"environmental": map[string]interface{}{"cdpRuntime": map[string]interface{}{"consoleAttached": true}},
+	})
+	found := false
+	for _, d := range got {
+		if strings.Contains(d.Reason, "console consumer attached") {
+			found = true
+			if !d.NonCorroborating {
+				t.Errorf("console-attach probe must be marked NonCorroborating: %+v", d)
+			}
+		} else if d.NonCorroborating {
+			t.Errorf("only the console-attach probe should carry the mark, got %+v", d)
+		}
+	}
+	if !found {
+		t.Fatal("expected the console-attach detection to fire")
+	}
+}
+
+// Live measurements from the webdecoy.com demo, 2026-09-09, v1.35.0. An
+// extension-driven click in a real Chrome: every environmental category clean,
+// vision_ai 0.40, behavioral 0.44, cdp 0.30 from the console probe alone,
+// weighted sum 0.189, allowed. Two independent views at 0.4 must now floor it.
+// Note vision_ai lands at 0.3999999999999999 — the epsilon is not decoration.
+func TestCorroborationCatchesTheExtensionDriver(t *testing.T) {
+	dets := []DetectionResult{
+		{Category: CategoryVisionAI, Score: 0.5, Confidence: 0.5},   // path unnaturally direct
+		{Category: CategoryVisionAI, Score: 0.4, Confidence: 0.5},   // click precision
+		{Category: CategoryBehavioral, Score: 0.6, Confidence: 0.7}, // insufficient movement
+		{Category: CategoryBehavioral, Score: 0.2, Confidence: 0.2}, // no scroll or keyboard
+		{Category: CategoryCDP, Score: 0.6, Confidence: 0.5, NonCorroborating: true},
+		{Category: CategoryFingerprint, Score: 0.4, Confidence: 0.4},
+	}
+	if got := applyCorroborationFloor(0.189, dets); got < 0.5 {
+		t.Errorf("two independent behavioural views at >=0.4 should floor the extension driver, got %v", got)
+	}
+}
+
+// The human-looking sessions logged beside it: "first interaction too soon"
+// and "no overshoot corrections" (behavioral 0.37) with the console probe
+// (cdp 0.30). One view plus a non-corroborating signal is not agreement.
+func TestCorroborationSparesADeveloperWithDevToolsOpen(t *testing.T) {
+	dets := []DetectionResult{
+		{Category: CategoryBehavioral, Score: 0.5, Confidence: 0.5},
+		{Category: CategoryBehavioral, Score: 0.4, Confidence: 0.4},
+		{Category: CategoryCDP, Score: 0.6, Confidence: 0.5, NonCorroborating: true},
+		{Category: CategoryFingerprint, Score: 0.4, Confidence: 0.4},
+	}
+	if got := applyCorroborationFloor(0.115, dets); got != 0.115 {
+		t.Errorf("a developer with DevTools open must not be floored, got %v", got)
 	}
 }
 

--- a/server-go/scoring.go
+++ b/server-go/scoring.go
@@ -51,6 +51,12 @@ type DetectionResult struct {
 	// automated, as opposed to one that merely correlates with automation.
 	// It triggers dispositiveFloor. See applyDispositiveFloor.
 	Dispositive bool
+
+	// NonCorroborating marks a signal that ordinary developer tooling also
+	// produces — DevTools open trips the console-attach probe — so it cannot
+	// stand as an independent behavioural view of the visitor. It still
+	// scores; it does not count towards applyCorroborationFloor's agreement.
+	NonCorroborating bool
 }
 
 // VerificationResult is the final result
@@ -663,7 +669,7 @@ func (e *ScoringEngine) verifyWithHeaders(signals map[string]interface{}, ip, si
 	// Calculate scores
 	categoryScores := e.calculateCategoryScores(detections)
 	finalScore := applyDispositiveFloor(e.calculateFinalScore(categoryScores), detections)
-	finalScore = applyCorroborationFloor(finalScore, categoryScores)
+	finalScore = applyCorroborationFloor(finalScore, detections)
 
 	// Determine recommendation
 	var recommendation string
@@ -1539,6 +1545,9 @@ func (e *ScoringEngine) detectCDP(signals map[string]interface{}) []DetectionRes
 			Score:      0.6,
 			Confidence: 0.5,
 			Reason:     "CDP/DevTools console consumer attached (automation protocol or open DevTools)",
+			// A developer with DevTools open produces exactly this signal, so it
+			// cannot be one of the independent views the corroboration floor counts.
+			NonCorroborating: true,
 		})
 	}
 
@@ -2265,27 +2274,45 @@ func applyDispositiveFloor(score float64, detections []DetectionResult) float64 
 //
 // # The rule
 //
-// When two or more behavioural categories independently reach 0.5, floor the
+// When two or more behavioural categories independently reach 0.4, floor the
 // score at 0.6. Corroboration across independent views is itself evidence,
 // distinct from any one of them being strong.
+//
+// # What does not count
+//
+// A signal that a developer's own tooling produces is not an independent view.
+// The DevTools console-attach probe fires for anyone with the console open, so
+// a detection marked NonCorroborating still scores its category but cannot be
+// one of the two that agree. Without that exclusion, lowering the bar would
+// have turned "developer with DevTools open and a quick click" into a block:
+// the human-looking sessions measured beside the adversary below sat at
+// behavioral 0.37 with cdp 0.30 from the probe alone.
 //
 // # Why these numbers
 //
 // Swept over a 40-point grid against the labelled corpus
 // (bench/tools/sweep-corroboration.js), not chosen by reasoning. The measurement
-// that decides it:
+// that decides it (2026-09-09, with the exclusion above applied):
 //
 //	threshold   humans reaching 2+     agents reaching 2+
-//	0.30         0 of 126               75 of 75
+//	0.30         0 of 126               66 of 75
 //	0.40         0 of 126               66 of 75
 //	0.50         0 of 126               66 of 75
-//	0.60         0 of 126               62 of 75
+//	0.60         0 of 126               56 of 75
 //	0.70         0 of 126               47 of 75
 //
 // No human in the panel reaches two agreeing behavioural categories at any
-// threshold tested. 0.5 sits mid-region — 0.3, 0.4 and 0.5 behave identically
-// and it falls off at 0.6 — so a real captured trace scoring somewhat lower than
-// the synthetic one still fires the rule.
+// threshold tested, and 0.3, 0.4 and 0.5 catch the same agents. What moved the
+// bar from 0.5 to 0.4 is a live measurement the corpus cannot make: an
+// extension-driven click in a real Chrome (chrome.debugger input, real
+// fingerprint, residential address) on the public demo scored vision_ai 0.40
+// and behavioral 0.44 with every environmental category clean — weighted sum
+// 0.189, allowed. At 0.5 the rule missed it in both views; at 0.4 it floors.
+// The panel's personas all carry twenty approach points, so the human this bar
+// could hit — fast hardware, cursor already near the target, short straight
+// click — is not in the corpus. TestCorroborationSparesADeveloperWithDevToolsOpen
+// pins the closest measured human shape; bench/README.md says what the panel
+// can and cannot support.
 //
 // Requiring three categories fails outright: all sixteen such combinations leave
 // the adversary at 0.234 or 0.423, still allowed. An earlier 3-of-4 rule chosen
@@ -2305,12 +2332,16 @@ func applyDispositiveFloor(score float64, detections []DetectionResult) float64 
 const (
 	// corroborationAgreeAt is the category score counting as one behavioural
 	// category agreeing.
-	corroborationAgreeAt = 0.5
+	corroborationAgreeAt = 0.4
 	// corroborationMinAgree is how many must agree. Two; three never fires.
 	corroborationMinAgree = 2
 	// corroborationFloor is where an agreeing verdict lands: a block, not the
 	// 0.9 reserved for self-declared automation.
 	corroborationFloor = 0.6
+	// corroborationEpsilon absorbs the few ulps a noisy-OR product lands from a
+	// round number (0.75×0.8 is 0.3999999999999999, not 0.4), so agreement does
+	// not depend on the order the arithmetic happened to run in.
+	corroborationEpsilon = 1e-9
 )
 
 // behaviouralCategories are the categories a browser trips by how it moves
@@ -2323,10 +2354,19 @@ var behaviouralCategories = []ThreatCategory{
 	CategoryCDP,
 }
 
-func applyCorroborationFloor(score float64, categoryScores map[string]float64) float64 {
+func applyCorroborationFloor(score float64, detections []DetectionResult) float64 {
+	// Only independent views count. A signal that a developer's own tooling
+	// produces (NonCorroborating) still scores, but cannot be one of the two.
+	corroborating := make([]DetectionResult, 0, len(detections))
+	for _, d := range detections {
+		if !d.NonCorroborating {
+			corroborating = append(corroborating, d)
+		}
+	}
+	categoryScores := noisyOrByCategory(corroborating)
 	agreeing := 0
 	for _, cat := range behaviouralCategories {
-		if categoryScores[string(cat)] >= corroborationAgreeAt {
+		if categoryScores[string(cat)] >= corroborationAgreeAt-corroborationEpsilon {
 			agreeing++
 		}
 	}
@@ -2336,7 +2376,11 @@ func applyCorroborationFloor(score float64, categoryScores map[string]float64) f
 	return score
 }
 
-func (e *ScoringEngine) calculateCategoryScores(detections []DetectionResult) map[string]float64 {
+// noisyOrByCategory combines the detections within each category: each is
+// independent evidence of strength score×confidence, and the category is the
+// probability that at least one is right. Categories with no detections are
+// absent from the result.
+func noisyOrByCategory(detections []DetectionResult) map[string]float64 {
 	// Probability that every detection in a category is wrong; the category
 	// score is one minus that.
 	survives := make(map[ThreatCategory]float64)
@@ -2353,6 +2397,11 @@ func (e *ScoringEngine) calculateCategoryScores(detections []DetectionResult) ma
 	for cat, s := range survives {
 		result[string(cat)] = math.Min(1.0, 1-s)
 	}
+	return result
+}
+
+func (e *ScoringEngine) calculateCategoryScores(detections []DetectionResult) map[string]float64 {
+	result := noisyOrByCategory(detections)
 
 	// Fill missing categories
 	for cat := range e.weights {

--- a/server-node/corroboration.test.js
+++ b/server-node/corroboration.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+// The behavioural corroboration floor. See engine.js for the measurement that
+// chose its constants; these pin the behaviour and the invariants that keep it
+// honest, and mirror server-go/corroboration_test.go.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  applyCorroborationFloor, calculateCategoryScores, detectCDP,
+  CORROBORATION_AGREE_AT, CORROBORATION_MIN_AGREE, CORROBORATION_FLOOR,
+  DISPOSITIVE_FLOOR, BEHAVIOURAL_CATEGORIES,
+} = require('./engine');
+
+// One detection per category at exactly the given strength, so each category's
+// noisy-OR score is the number written here.
+const views = (cats) => Object.entries(cats).map(([category, score]) => ({ category, score, confidence: 1 }));
+
+test('two agreeing behavioural categories floor the score', () => {
+  const dets = views({ vision_ai: 0.652, behavioral: 0.597, automation: 0.36 });
+  assert.equal(applyCorroborationFloor(0.234, dets), CORROBORATION_FLOOR);
+});
+
+test('one category alone never floors, however strong', () => {
+  for (const c of BEHAVIOURAL_CATEGORIES) {
+    assert.equal(applyCorroborationFloor(0.2, views({ [c]: 1 })), 0.2, `${c} alone must not floor`);
+  }
+});
+
+test('non-behavioural categories do not corroborate', () => {
+  assert.equal(applyCorroborationFloor(0.3, views({ headless: 1, fingerprint: 1, datacenter: 1, bot: 1 })), 0.3);
+});
+
+test('the floor never lowers a score', () => {
+  assert.equal(applyCorroborationFloor(0.95, views({ vision_ai: 0.9, behavioral: 0.9 })), 0.95);
+});
+
+test('agreement starts exactly at the threshold', () => {
+  const under = CORROBORATION_AGREE_AT - 0.01;
+  assert.equal(applyCorroborationFloor(0.2, views({ vision_ai: under, behavioral: under })), 0.2);
+  const at = CORROBORATION_AGREE_AT;
+  assert.equal(applyCorroborationFloor(0.2, views({ vision_ai: at, behavioral: at })), CORROBORATION_FLOOR);
+});
+
+test('the floor blocks, sits below the dispositive floor, and needs exactly two views', () => {
+  assert.ok(CORROBORATION_FLOOR >= 0.5);
+  assert.ok(CORROBORATION_FLOOR < DISPOSITIVE_FLOOR);
+  assert.equal(CORROBORATION_MIN_AGREE, 2);
+});
+
+test('a non-corroborating detection cannot be the second view', () => {
+  const consoleAttached = { category: 'cdp', score: 0.6, confidence: 1, nonCorroborating: true };
+  const movement = { category: 'behavioral', score: CORROBORATION_AGREE_AT, confidence: 1 };
+  assert.equal(applyCorroborationFloor(0.2, [consoleAttached, movement]), 0.2);
+  // Same evidence from an independent view does floor: provenance, not strength.
+  assert.equal(applyCorroborationFloor(0.2, [{ ...consoleAttached, nonCorroborating: false }, movement]), CORROBORATION_FLOOR);
+});
+
+test('a non-corroborating detection still scores its category', () => {
+  const scores = calculateCategoryScores([{ category: 'cdp', score: 0.6, confidence: 0.5, nonCorroborating: true }]);
+  assert.ok(Math.abs(scores.cdp - 0.3) < 1e-9, `cdp scored ${scores.cdp}`);
+});
+
+test('the console-attach probe carries the mark, and only it', () => {
+  const dets = detectCDP({ behavioral: { touchEvents: 0 }, environmental: { cdpRuntime: { consoleAttached: true } } });
+  const probe = dets.find((d) => /console consumer attached/.test(d.reason));
+  assert.ok(probe, 'expected the console-attach detection to fire');
+  assert.equal(probe.nonCorroborating, true);
+  assert.equal(dets.filter((d) => d.nonCorroborating).length, 1);
+});
+
+// Live measurements from the webdecoy.com demo, 2026-09-09, v1.35.0. An
+// extension-driven click in a real Chrome: every environmental category clean,
+// vision_ai 0.40, behavioral 0.44, cdp 0.30 from the console probe alone,
+// weighted sum 0.189, allowed. vision_ai lands at 0.3999999999999999, so the
+// epsilon is load-bearing here.
+test('the extension-driven click that passed at 0.5 is floored at 0.4', () => {
+  const dets = [
+    { category: 'vision_ai', score: 0.5, confidence: 0.5 },   // path unnaturally direct
+    { category: 'vision_ai', score: 0.4, confidence: 0.5 },   // click precision
+    { category: 'behavioral', score: 0.6, confidence: 0.7 },  // insufficient movement
+    { category: 'behavioral', score: 0.2, confidence: 0.2 },  // no scroll or keyboard
+    { category: 'cdp', score: 0.6, confidence: 0.5, nonCorroborating: true },
+    { category: 'fingerprint', score: 0.4, confidence: 0.4 },
+  ];
+  assert.ok(applyCorroborationFloor(0.189, dets) >= 0.5);
+});
+
+test('a developer with DevTools open and a quick click is not floored', () => {
+  const dets = [
+    { category: 'behavioral', score: 0.5, confidence: 0.5 },  // first interaction too soon
+    { category: 'behavioral', score: 0.4, confidence: 0.4 },  // no overshoot corrections
+    { category: 'cdp', score: 0.6, confidence: 0.5, nonCorroborating: true },
+    { category: 'fingerprint', score: 0.4, confidence: 0.4 },
+  ];
+  assert.equal(applyCorroborationFloor(0.115, dets), 0.115);
+});

--- a/server-node/engine.js
+++ b/server-node/engine.js
@@ -495,7 +495,10 @@ function detectCDP(signals) {
   if (env.cdpRuntime && env.cdpRuntime.consoleAttached) {
     detections.push({
       category: 'cdp', score: 0.6, confidence: 0.5,
-      reason: 'CDP/DevTools console consumer attached (automation protocol or open DevTools)'
+      reason: 'CDP/DevTools console consumer attached (automation protocol or open DevTools)',
+      // A developer with DevTools open produces exactly this signal, so it
+      // cannot be one of the independent views the corroboration floor counts.
+      nonCorroborating: true
     });
   }
 
@@ -912,33 +915,47 @@ function applyDispositiveFloor(score, detections) {
  * product. It treats absence of environmental evidence as evidence of absence — but
  * on this adversary a clean environment is the attack working, not innocence.
  *
- * The rule: when two or more behavioural categories independently reach 0.5, floor
- * the score at 0.6.
+ * The rule: when two or more behavioural categories independently reach 0.4, floor
+ * the score at 0.6. A signal a developer's own tooling produces is not an
+ * independent view: the DevTools console-attach probe is marked nonCorroborating,
+ * so it still scores but cannot be one of the two that agree.
  *
  * Constants swept over a 40-point grid against the labelled corpus
  * (bench/tools/sweep-corroboration.js), not reasoned about. No human in the
  * 126-sample panel reaches two agreeing behavioural categories at any threshold
- * tested, while 66 of 75 agents do at 0.5. Requiring three fails outright — all
- * sixteen such combinations leave the adversary allowed. The floor value does not
- * affect separation, so 0.6 is a policy choice: the block boundary, kept distinct
- * from the 0.9 reserved for a browser that declares its own automation.
+ * tested, and 0.3, 0.4 and 0.5 catch the same 66 of 75 agents. The bar moved from
+ * 0.5 to 0.4 on a live measurement the corpus cannot make (2026-09-09): an
+ * extension-driven click in a real Chrome on the public demo scored vision_ai 0.40
+ * and behavioral 0.44 with every environmental category clean — weighted sum
+ * 0.189, allowed at 0.5, floored at 0.4. The exclusion is what keeps the lower
+ * bar honest: the human-looking sessions beside it sat at behavioral 0.37 with cdp
+ * 0.30 from the console probe alone. Requiring three fails outright — all sixteen
+ * such combinations leave the adversary allowed. The floor value does not affect
+ * separation, so 0.6 is a policy choice: the block boundary, kept distinct from
+ * the 0.9 reserved for a browser that declares its own automation.
  *
  * Caveat: the adversary is one synthetic, hand-authored sample. This shows the
  * arithmetic works on the shape the corpus describes, not that it works on a real
  * source-patched browser.
  */
-const CORROBORATION_AGREE_AT = 0.5;
+const CORROBORATION_AGREE_AT = 0.4;
 const CORROBORATION_MIN_AGREE = 2;
 const CORROBORATION_FLOOR = 0.6;
+// Absorbs the few ulps a noisy-OR product lands from a round number (0.75×0.8 is
+// 0.3999999999999999, not 0.4), so agreement does not depend on arithmetic order.
+const CORROBORATION_EPSILON = 1e-9;
 
 // Categories a browser trips by how it moves rather than by what it is. A
 // patched binary can hide what it is; it cannot hide that nothing is moving the
 // pointer like a hand.
 const BEHAVIOURAL_CATEGORIES = ['vision_ai', 'behavioral', 'automation', 'cdp'];
 
-function applyCorroborationFloor(score, categoryScores) {
+function applyCorroborationFloor(score, detections) {
+  // Only independent views count. A signal that a developer's own tooling
+  // produces (nonCorroborating) still scores, but cannot be one of the two.
+  const categoryScores = calculateCategoryScores(detections.filter((d) => !d.nonCorroborating));
   const agreeing = BEHAVIOURAL_CATEGORIES
-    .filter((c) => (categoryScores[c] || 0) >= CORROBORATION_AGREE_AT).length;
+    .filter((c) => (categoryScores[c] || 0) >= CORROBORATION_AGREE_AT - CORROBORATION_EPSILON).length;
   return agreeing >= CORROBORATION_MIN_AGREE ? Math.max(score, CORROBORATION_FLOOR) : score;
 }
 

--- a/server-node/index.js
+++ b/server-node/index.js
@@ -345,7 +345,7 @@ class ScoringEngine {
     const categoryScores = calculateCategoryScores(detections, this.weights);
     const finalScore = applyCorroborationFloor(
       applyDispositiveFloor(calculateFinalScore(categoryScores, this.weights), detections),
-      categoryScores
+      detections
     );
 
     let recommendation;

--- a/server-node/package.json
+++ b/server-node/package.json
@@ -15,7 +15,7 @@
     "test:clientip": "node clientip.test.js",
     "test:limits": "node limits.test.js",
     "test:detection": "node detection.test.js",
-    "test": "node version.test.js && node config.test.js && node clientip.test.js && node limits.test.js && node detection.test.js && node inputforensics.test.js && node interactionmode.test.js && node exemptions.test.js && node webbotauth.test.js && node siteverify.test.js && node redis-state.test.js && node index.test.js && node --test suspicion.test.js security.test.js",
+    "test": "node version.test.js && node config.test.js && node clientip.test.js && node limits.test.js && node detection.test.js && node inputforensics.test.js && node interactionmode.test.js && node exemptions.test.js && node webbotauth.test.js && node siteverify.test.js && node redis-state.test.js && node index.test.js && node --test suspicion.test.js security.test.js corroboration.test.js",
     "test:siteverify": "node siteverify.test.js",
     "test:forensics": "node inputforensics.test.js",
     "test:suspicion": "node --test suspicion.test.js"

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -728,7 +728,7 @@ async function runVerification(signals, ip, siteKey, userAgent, headers = {}, ja
   const categoryScores = calculateCategoryScores(detections);
   const finalScore = applyCorroborationFloor(
     applyDispositiveFloor(calculateFinalScore(categoryScores), detections),
-    categoryScores
+    detections
   );
 
   let recommendation;

--- a/server-python/server.py
+++ b/server-python/server.py
@@ -326,6 +326,12 @@ class Detection:
     # DISPOSITIVE_FLOOR - see apply_dispositive_floor.
     dispositive: bool = False
 
+    # Marks a signal that ordinary developer tooling also produces - DevTools
+    # open trips the console-attach probe - so it cannot stand as an independent
+    # behavioural view of the visitor. It still scores; it does not count
+    # towards apply_corroboration_floor's agreement.
+    non_corroborating: bool = False
+
 
 # =============================================================================
 # Rate Limiter (In-Memory - Use Redis in production)
@@ -1098,7 +1104,10 @@ def detect_cdp(signals: Dict) -> List[Detection]:
     if env.get("cdpRuntime", {}).get("consoleAttached"):
         detections.append(Detection(
             ThreatCategory.CDP, 0.6, 0.5,
-            "CDP/DevTools console consumer attached (automation protocol or open DevTools)"
+            "CDP/DevTools console consumer attached (automation protocol or open DevTools)",
+            # A developer with DevTools open produces exactly this signal, so it
+            # cannot be one of the independent views the corroboration floor counts.
+            non_corroborating=True,
         ))
 
     if not cdp.get("detected"):
@@ -1541,23 +1550,34 @@ def apply_dispositive_floor(score: float, detections: List[Detection]) -> float:
 # product. It treats absence of environmental evidence as evidence of absence — but
 # on this adversary a clean environment is the attack working, not innocence.
 #
-# The rule: when two or more behavioural categories independently reach 0.5, floor
-# the score at 0.6.
+# The rule: when two or more behavioural categories independently reach 0.4, floor
+# the score at 0.6. A signal a developer's own tooling produces is not an
+# independent view: the DevTools console-attach probe is marked non_corroborating,
+# so it still scores but cannot be one of the two that agree.
 #
 # Constants swept over a 40-point grid against the labelled corpus
 # (bench/tools/sweep-corroboration.js), not reasoned about. No human in the
 # 126-sample panel reaches two agreeing behavioural categories at any threshold
-# tested, while 66 of 75 agents do at 0.5. Requiring three fails outright — all
-# sixteen such combinations leave the adversary allowed. The floor value does not
-# affect separation, so 0.6 is a policy choice: the block boundary, kept distinct
-# from the 0.9 reserved for a browser that declares its own automation.
+# tested, and 0.3, 0.4 and 0.5 catch the same 66 of 75 agents. The bar moved from
+# 0.5 to 0.4 on a live measurement the corpus cannot make (2026-09-09): an
+# extension-driven click in a real Chrome on the public demo scored vision_ai 0.40
+# and behavioral 0.44 with every environmental category clean - weighted sum
+# 0.189, allowed at 0.5, floored at 0.4. The exclusion is what keeps the lower
+# bar honest: the human-looking sessions beside it sat at behavioral 0.37 with cdp
+# 0.30 from the console probe alone. Requiring three fails outright - all sixteen
+# such combinations leave the adversary allowed. The floor value does not affect
+# separation, so 0.6 is a policy choice: the block boundary, kept distinct from
+# the 0.9 reserved for a browser that declares its own automation.
 #
 # Caveat: the adversary is one synthetic, hand-authored sample. This shows the
 # arithmetic works on the shape the corpus describes, not that it works on a real
 # source-patched browser.
-CORROBORATION_AGREE_AT = 0.5
+CORROBORATION_AGREE_AT = 0.4
 CORROBORATION_MIN_AGREE = 2
 CORROBORATION_FLOOR = 0.6
+# Absorbs the few ulps a noisy-OR product lands from a round number (0.75*0.8 is
+# 0.3999999999999999, not 0.4), so agreement does not depend on arithmetic order.
+CORROBORATION_EPSILON = 1e-9
 
 # Categories a browser trips by how it moves rather than by what it is. A patched
 # binary can hide what it is; it cannot hide that nothing is moving the pointer
@@ -1565,10 +1585,15 @@ CORROBORATION_FLOOR = 0.6
 BEHAVIOURAL_CATEGORIES = ["vision_ai", "behavioral", "automation", "cdp"]
 
 
-def apply_corroboration_floor(score: float, category_scores: Dict[str, float]) -> float:
+def apply_corroboration_floor(score: float, detections: List[Detection]) -> float:
+    # Only independent views count. A signal that a developer's own tooling
+    # produces (non_corroborating) still scores, but cannot be one of the two.
+    category_scores = calculate_category_scores(
+        [d for d in detections if not d.non_corroborating]
+    )
     agreeing = sum(
         1 for c in BEHAVIOURAL_CATEGORIES
-        if category_scores.get(c, 0) >= CORROBORATION_AGREE_AT
+        if category_scores.get(c, 0) >= CORROBORATION_AGREE_AT - CORROBORATION_EPSILON
     )
     if agreeing >= CORROBORATION_MIN_AGREE:
         return max(score, CORROBORATION_FLOOR)
@@ -1908,7 +1933,7 @@ def run_verification(
     category_scores = calculate_category_scores(detections)
     final_score = apply_corroboration_floor(
         apply_dispositive_floor(calculate_final_score(category_scores), detections),
-        category_scores,
+        detections,
     )
 
     if final_score < 0.3:

--- a/server-python/test_detection.py
+++ b/server-python/test_detection.py
@@ -23,6 +23,11 @@ from server import (
     run_verification,
     set_interaction_mode,
     DISPOSITIVE_FLOOR,
+    apply_corroboration_floor,
+    detect_cdp,
+    BEHAVIOURAL_CATEGORIES,
+    CORROBORATION_AGREE_AT,
+    CORROBORATION_FLOOR,
 )
 
 test = TestRegistry()
@@ -235,6 +240,97 @@ def client_cannot_claim_invisible_mode():
     spoofed["serverContext"] = {"widgetInteraction": False}
     set_interaction_mode(spoofed, True)
     assert has_widget_interaction(spoofed) is True
+
+
+# ---------------------------------------------------------------------------
+# Behavioural corroboration floor. Mirrors server-go/corroboration_test.go.
+# ---------------------------------------------------------------------------
+
+def views(cats):
+    """One detection per category at exactly the given strength, so each
+    category's noisy-OR score is the number written here."""
+    return [Detection(ThreatCategory(c), s, 1.0, c) for c, s in cats.items()]
+
+
+@test
+def two_agreeing_behavioural_categories_floor_the_score():
+    got = apply_corroboration_floor(0.234, views({"vision_ai": 0.652, "behavioral": 0.597, "automation": 0.36}))
+    assert got == CORROBORATION_FLOOR, got
+
+
+@test
+def one_category_alone_never_floors_however_strong():
+    for c in BEHAVIOURAL_CATEGORIES:
+        assert apply_corroboration_floor(0.2, views({c: 1.0})) == 0.2, c
+
+
+@test
+def non_behavioural_categories_do_not_corroborate():
+    assert apply_corroboration_floor(0.3, views({"headless": 1.0, "fingerprint": 1.0, "bot": 1.0})) == 0.3
+
+
+@test
+def the_floor_never_lowers_a_score():
+    assert apply_corroboration_floor(0.95, views({"vision_ai": 0.9, "behavioral": 0.9})) == 0.95
+
+
+@test
+def agreement_starts_exactly_at_the_threshold():
+    under = CORROBORATION_AGREE_AT - 0.01
+    assert apply_corroboration_floor(0.2, views({"vision_ai": under, "behavioral": under})) == 0.2
+    at = CORROBORATION_AGREE_AT
+    assert apply_corroboration_floor(0.2, views({"vision_ai": at, "behavioral": at})) == CORROBORATION_FLOOR
+
+
+@test
+def a_non_corroborating_detection_cannot_be_the_second_view():
+    console = Detection(ThreatCategory.CDP, 0.6, 1.0, "console attached", non_corroborating=True)
+    movement = Detection(ThreatCategory.BEHAVIORAL, CORROBORATION_AGREE_AT, 1.0, "movement")
+    assert apply_corroboration_floor(0.2, [console, movement]) == 0.2
+    # Same evidence from an independent view does floor: provenance, not strength.
+    independent = Detection(ThreatCategory.CDP, 0.6, 1.0, "independent view")
+    assert apply_corroboration_floor(0.2, [independent, movement]) == CORROBORATION_FLOOR
+
+
+@test
+def a_non_corroborating_detection_still_scores_its_category():
+    scores = calculate_category_scores([Detection(ThreatCategory.CDP, 0.6, 0.5, "console", non_corroborating=True)])
+    assert abs(scores["cdp"] - 0.3) < 1e-9, scores
+
+
+@test
+def the_console_attach_probe_carries_the_mark_and_only_it():
+    dets = detect_cdp({"behavioral": {"touchEvents": 0}, "environmental": {"cdpRuntime": {"consoleAttached": True}}})
+    probe = [d for d in dets if "console consumer attached" in d.reason]
+    assert probe and probe[0].non_corroborating, dets
+    assert sum(1 for d in dets if d.non_corroborating) == 1, dets
+
+
+@test
+def the_extension_driven_click_that_passed_at_0_5_is_floored_at_0_4():
+    # Live measurement, webdecoy.com demo 2026-09-09, v1.35.0: vision_ai 0.40
+    # (0.3999999999999999 in floating point), behavioral 0.44, cdp 0.30 from the
+    # console probe alone, weighted sum 0.189, allowed.
+    dets = [
+        Detection(ThreatCategory.VISION_AI, 0.5, 0.5, "path unnaturally direct"),
+        Detection(ThreatCategory.VISION_AI, 0.4, 0.5, "click precision"),
+        Detection(ThreatCategory.BEHAVIORAL, 0.6, 0.7, "insufficient movement"),
+        Detection(ThreatCategory.BEHAVIORAL, 0.2, 0.2, "no scroll or keyboard"),
+        Detection(ThreatCategory.CDP, 0.6, 0.5, "console attached", non_corroborating=True),
+        Detection(ThreatCategory.FINGERPRINT, 0.4, 0.4, "canvas blocked"),
+    ]
+    assert apply_corroboration_floor(0.189, dets) >= 0.5
+
+
+@test
+def a_developer_with_devtools_open_and_a_quick_click_is_not_floored():
+    dets = [
+        Detection(ThreatCategory.BEHAVIORAL, 0.5, 0.5, "first interaction too soon"),
+        Detection(ThreatCategory.BEHAVIORAL, 0.4, 0.4, "no overshoot corrections"),
+        Detection(ThreatCategory.CDP, 0.6, 0.5, "console attached", non_corroborating=True),
+        Detection(ThreatCategory.FINGERPRINT, 0.4, 0.4, "canvas blocked"),
+    ]
+    assert apply_corroboration_floor(0.115, dets) == 0.115
 
 
 DetectionTests = test.testcase("DetectionTests")


### PR DESCRIPTION
## What and why

An extension-driven click in a real browser reached two behavioural categories just under 0.5 with a clean environment and was allowed. Two independent behavioural categories at 0.4 now floor the score at 0.6 and withhold the token, on Go, Node and Python.

The DevTools console-attach probe is marked non-corroborating. It still scores its category but cannot be one of the two agreeing views, because a developer with the console open produces the same signal. Agreement is recomputed from the unmarked detections and compared with a small epsilon, since noisy-OR products land just below round numbers.

## Validation

- Sweep with the exclusion applied: 0 of 126 human samples reach two agreeing categories at any threshold; 66 of 75 agents at 0.3, 0.4 and 0.5.
- `run-bench.js --gate`: human FPR 0.00% (0/126), agent TPR 97.33%, gate PASS.
- New corroboration tests in all three servers, including the measured extension-click shape (floors) and the DevTools-open shape (does not).
- Go vet and test, Node and Python suites pass.

## Compatibility

Sessions with two behavioural categories between 0.4 and 0.5 now score at least 0.6. No API change.

https://claude.ai/code/session_0198hVg9KALKecyEFDhsDxdg