### PR TITLE
Gate tokens on per-device rate; require human key holds for the keyboard exemption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ the project uses [Semantic Versioning](https://semver.org/) — with the caveat
 that pre-2.0 it has used minor bumps for behaviour changes that a stricter
 reading would call major. Read the **Breaking** entries rather than the number.
 
+## [Unreleased]
+
+### Security and fixes
+- Withhold the token when one page instance on one device at one address
+  verifies more than 10 times in a minute (`reason: rate_limited`). The
+  per-address rate detection stays as it was; it carries almost no weight, so
+  it could not stop an automated client verifying every few seconds. Keyed on
+  the widget instance as well, so identical machines behind one address do not
+  share a budget.
+- The keyboard-only accessibility exemption now checks that key holds look
+  like fingers when hold data is present. A keyboard-driven agent releases keys
+  in a millisecond or two and no longer passes as a keyboard user; a visitor
+  with no hold data, including one on an older widget, keeps the exemption.
+  The widget reports an average key hold alongside its key count.
+
 ## [1.36.0] — 2026-09-09
 
 ### Detection

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -81,6 +81,7 @@ Redis persistence and backups. FCaptcha itself does not write state to disk.
 | Suspicion ledger (adaptive cost) | site key + IP | 15 minutes |
 | Fingerprint cardinality | site + fingerprint / IP | 15-minute fixed windows; at most 16 members per bucket |
 | Rate-limit counters | site key + IP | 60-second windows |
+| Per-device verification counters | site key + IP + device fingerprint + widget instance | 60-second windows |
 | Site-key state bounds | IP | 1 hour |
 | Siteverify idempotency cache | caller-supplied key | 5 minutes |
 | TLS fingerprints, when terminating TLS | connection | 5 minutes |

--- a/README.md
+++ b/README.md
@@ -602,6 +602,7 @@ challenge:
 | The score is below the success threshold (0.5) | (score speaks for itself) |
 | A **valid proof of work** for a challenge this server issued, with the signals bound to it | `pow_not_satisfied` |
 | The minting origin is permitted, if `FCAPTCHA_ALLOWED_HOSTNAMES` is set | `hostname_not_allowed` |
+| Fewer than 10 verifications in the last minute from this page instance, device and address | `rate_limited` |
 
 The widget solves a proof of work on every path and aborts rather than submit
 without one, so a request that arrives without a valid solution did not come from

--- a/bench/README.md
+++ b/bench/README.md
@@ -19,6 +19,12 @@ node capture/record.js
 node run-bench.js                     # human FPR, agent TPR, per-signal budgets
 node run-bench.js --gate              # non-zero exit when a signal is over budget
 node run-bench.js --json out.json     # machine-readable
+
+On macOS, run the server and the harness under `caffeinate -i -s` for anything
+unattended. Maintenance Sleep pauses both processes together; a challenge
+fetched just before a pause is past its five-minute lifetime when the solve
+resumes, and the gate reports it as `PoW verification failed: challenge_expired`
+on whichever personas were in flight.
 ```
 
 ---

--- a/bench/capture/input.js
+++ b/bench/capture/input.js
@@ -231,15 +231,20 @@ const HUMAN_PERSONAS = {
       'keyboard-only: zero pointer events, Tab to focus, Space to activate. ' +
       'Directly exercises the accessibility exemption (keyEvents >= 2 && totalPoints === 0).',
     async run({ page, target, rng }) {
-      await page.keyboard.press('Tab');
+      // Hold each key the way a finger does. Playwright's default press has a
+      // hold of a millisecond or two, which is what an automation protocol
+      // produces and what the server's key-hold check exists to catch; a human
+      // persona that pressed keys that way would be measuring the harness.
+      const hold = () => ({ delay: Math.max(30, rng.gaussian(80, 25)) });
+      await page.keyboard.press('Tab', hold());
       await sleep(rng.range(300, 900));
       for (let i = 0; i < 3 && !(await target.evaluate((el) => el === document.activeElement)); i++) {
-        await page.keyboard.press('Tab');
+        await page.keyboard.press('Tab', hold());
         await sleep(rng.range(200, 700));
       }
       await target.focus();
       await sleep(rng.range(400, 1200));
-      await page.keyboard.press('Space');
+      await page.keyboard.press('Space', hold());
     },
   },
 
@@ -249,13 +254,14 @@ const HUMAN_PERSONAS = {
       'is announced, no pointer. Dwell times are a plausible range, not measured ' +
       'against a real AT user.',
     async run({ page, target, rng }) {
+      const hold = () => ({ delay: Math.max(30, rng.gaussian(80, 25)) }); // see keyboard-only
       for (let i = 0; i < 6; i++) {
-        await page.keyboard.press('Tab');
+        await page.keyboard.press('Tab', hold());
         await sleep(rng.range(900, 2400)); // announcement time
       }
       await target.focus();
       await sleep(rng.range(1200, 2600));
-      await page.keyboard.press('Space');
+      await page.keyboard.press('Space', hold());
     },
   },
 

--- a/client/fcaptcha.js
+++ b/client/fcaptcha.js
@@ -199,6 +199,9 @@
   // Behavioral Signal Collector
   // ============================================================
 
+  // Keys whose hold says nothing about typing: held across other presses.
+  const KEY_HOLD_EXCLUDED = new Set(['Shift', 'Control', 'Alt', 'Meta', 'CapsLock', 'NumLock', 'ScrollLock']);
+
   class BehavioralCollector {
     constructor() {
       this.mousePositions = [];
@@ -222,6 +225,13 @@
       // Cross-input activity timeline for think-time cadence.
       this._lastActivityT = null;
       this._cadenceGaps = [];
+      // Key hold (keydown→keyup) per physical key. Only durations are kept —
+      // never which key — and modifiers and auto-repeat are excluded. A hand
+      // on a key holds it for tens of milliseconds; an automation protocol
+      // releases it in one or two. The server reads the summary before it
+      // grants the keyboard-only accessibility exemption.
+      this._keyDownAt = new Map();
+      this.keyHolds = [];
       this._teleportClicks = 0;
       // Coalesced pointermove batches: real mice coalesce multiple hardware
       // samples per frame; CDP-injected moves produce single-entry batches.
@@ -328,6 +338,17 @@
         keyLength: e.key ? e.key.length : 0, // Don't store actual keys
         t: now
       });
+      const keyId = e.code || e.key;
+      if (!keyId || KEY_HOLD_EXCLUDED.has(e.key)) return;
+      if (e.type === 'keydown') {
+        if (!e.repeat) this._keyDownAt.set(keyId, now);
+      } else if (e.type === 'keyup') {
+        const downAt = this._keyDownAt.get(keyId);
+        if (downAt === undefined) return;
+        this._keyDownAt.delete(keyId);
+        const hold = now - downAt;
+        if (hold > 0 && hold < 2000 && this.keyHolds.length < 200) this.keyHolds.push(hold);
+      }
     }
 
     recordTouch(e) {
@@ -626,6 +647,7 @@
         scrollEvents: this.scrollEvents.length,
         scrollMorphology: this._analyzeScrollMorphology(),
         keyEvents: this.keyEvents.length,
+        ...this._keyHoldSummary(),
         touchEvents: this.touchEvents.length,
         focusEvents: this.focusEvents.length,
         clickData: this.clickData,
@@ -898,6 +920,15 @@
       return arr.reduce((sum, val) => sum + Math.pow(val - mean, 2), 0) / arr.length;
     }
 
+    // Average keydown→keyup hold and how many presses it rests on.
+    _keyHoldSummary() {
+      const n = this.keyHolds.length;
+      return {
+        keyHoldSamples: n,
+        keyHoldAvg: n ? this.keyHolds.reduce((a, b) => a + b, 0) / n : 0
+      };
+    }
+
     _getEmptyAnalysis(totalPoints = 0) {
       return {
         // A short trace is insufficient for stable trajectory statistics, but
@@ -910,6 +941,7 @@
         scrollEvents: this.scrollEvents.length,
         scrollMorphology: this._analyzeScrollMorphology(),
         keyEvents: this.keyEvents.length,
+        ...this._keyHoldSummary(),
         touchEvents: this.touchEvents.length, focusEvents: this.focusEvents.length,
         clickData: this.clickData, interactionDuration: Date.now() - this.startTime,
         inputForensics: this._analyzeInputForensics(),

--- a/server-go/device_rate_test.go
+++ b/server-go/device_rate_test.go
@@ -1,0 +1,73 @@
+package main
+
+import "testing"
+
+// The per-device verification rate gate. A precondition on token issuance, not
+// weighted evidence: see deviceVerificationsPerMinute in scoring.go.
+
+func deviceSignals(instance string) map[string]interface{} {
+	sig := map[string]interface{}{
+		"behavioral": map[string]interface{}{
+			"totalPoints": 60.0, "trajectoryLength": 400.0, "approachPoints": 12.0,
+			"approachDirectness": 0.4, "microTremorScore": 0.5, "velocityVariance": 0.5,
+		},
+		"environmental": map[string]interface{}{"automationFlags": map[string]interface{}{}},
+	}
+	if instance != "" {
+		sig["meta"] = map[string]interface{}{"sessionId": instance}
+	}
+	return sig
+}
+
+func TestDeviceRateGateWithholdsTheEleventhVerification(t *testing.T) {
+	e := NewScoringEngine("test-secret")
+	const ip = "203.0.113.77"
+	for i := 0; i < deviceVerificationsPerMinute; i++ {
+		r := e.VerifyWithHeaders(deviceSignals("page-a"), ip, "site", "ua", nil, "", "", false, nil, TokenBinding{})
+		if r.Reason == "rate_limited" {
+			t.Fatalf("verification %d of %d was rate limited early", i+1, deviceVerificationsPerMinute)
+		}
+	}
+	r := e.VerifyWithHeaders(deviceSignals("page-a"), ip, "site", "ua", nil, "", "", false, nil, TokenBinding{})
+	if r.Success || r.Reason != "rate_limited" {
+		t.Errorf("verification %d should be withheld as rate_limited, got success=%v reason=%q",
+			deviceVerificationsPerMinute+1, r.Success, r.Reason)
+	}
+	if !hasReasonContaining(r.Detections, "for this device") {
+		t.Errorf("expected the per-device rate detection to be recorded, got %+v", r.Detections)
+	}
+
+	// Another page instance on the same address and device has its own budget:
+	// identical machines behind one NAT must not share one.
+	other := e.VerifyWithHeaders(deviceSignals("page-b"), ip, "site", "ua", nil, "", "", false, nil, TokenBinding{})
+	if other.Reason == "rate_limited" {
+		t.Errorf("a different widget instance must not inherit the exhausted budget")
+	}
+}
+
+func TestDeviceRateGateNeedsAWidgetInstance(t *testing.T) {
+	// A client that reports no instance id — an older widget — is not gated,
+	// because the alternative key (address + fingerprint) is shared by every
+	// identical machine behind one address.
+	e := NewScoringEngine("test-secret")
+	for i := 0; i <= deviceVerificationsPerMinute+2; i++ {
+		r := e.VerifyWithHeaders(deviceSignals(""), "203.0.113.78", "site", "ua", nil, "", "", false, nil, TokenBinding{})
+		if r.Reason == "rate_limited" {
+			t.Fatalf("no instance id must mean no device gate, got rate_limited on call %d", i+1)
+		}
+	}
+}
+
+func TestWidgetInstanceIsBounded(t *testing.T) {
+	long := make([]byte, 500)
+	for i := range long {
+		long[i] = 'x'
+	}
+	sig := map[string]interface{}{"meta": map[string]interface{}{"widgetId": string(long)}}
+	if got := widgetInstance(sig); len(got) != 64 {
+		t.Errorf("client-supplied id must be bounded before it becomes a key, got length %d", len(got))
+	}
+	if widgetInstance(map[string]interface{}{}) != "" {
+		t.Error("no meta means no instance")
+	}
+}

--- a/server-go/keyboard_exemption_test.go
+++ b/server-go/keyboard_exemption_test.go
@@ -1,0 +1,100 @@
+package main
+
+import "testing"
+
+// The keyboard-only accessibility exemption and the key-hold check that keeps a
+// keyboard-driven agent from claiming it. See keyboardOnlyUser in scoring.go.
+
+func keyboardSignals(keyEvents float64, extra map[string]interface{}) map[string]interface{} {
+	b := map[string]interface{}{"totalPoints": 0.0, "trajectoryLength": 0.0, "keyEvents": keyEvents, "touchEvents": 0.0}
+	for k, v := range extra {
+		b[k] = v
+	}
+	return map[string]interface{}{
+		"behavioral":    b,
+		"environmental": map[string]interface{}{"automationFlags": map[string]interface{}{}},
+	}
+}
+
+func TestKeyboardExemptionStandsWithoutHoldData(t *testing.T) {
+	// An older widget, or a visitor who tabbed to the checkbox and pressed
+	// Space without typing into a field, reports counts and nothing else.
+	sig := keyboardSignals(8, nil)
+	if !keyboardOnlyUser(sig, getMap(sig, "behavioral")) {
+		t.Error("counts alone must keep the exemption")
+	}
+}
+
+func TestKeyboardExemptionStandsForFingers(t *testing.T) {
+	sig := keyboardSignals(12, map[string]interface{}{"keyHoldSamples": 6.0, "keyHoldAvg": 85.0})
+	if !keyboardOnlyUser(sig, getMap(sig, "behavioral")) {
+		t.Error("85ms holds are a hand on a key")
+	}
+}
+
+func TestKeyboardExemptionDeniedForMechanicalHolds(t *testing.T) {
+	sig := keyboardSignals(12, map[string]interface{}{"keyHoldSamples": 6.0, "keyHoldAvg": 4.0})
+	if keyboardOnlyUser(sig, getMap(sig, "behavioral")) {
+		t.Error("4ms holds are an automation protocol, not a keyboard user")
+	}
+}
+
+func TestKeyboardExemptionPoolsFormFieldDwell(t *testing.T) {
+	// The form analyser's per-field dwell times count too, so a widget that
+	// typed into a field is judged even without the session-level summary.
+	mechanical := keyboardSignals(9, nil)
+	mechanical["formAnalysis"] = map[string]interface{}{"textareaKeyboard": map[string]interface{}{
+		"message": map[string]interface{}{"dwellTimes": []interface{}{2.0, 3.0, 1.0, 2.0}},
+	}}
+	if keyboardOnlyUser(mechanical, getMap(mechanical, "behavioral")) {
+		t.Error("mechanical field dwell must deny the exemption")
+	}
+	human := keyboardSignals(9, nil)
+	human["formAnalysis"] = map[string]interface{}{"textareaKeyboard": map[string]interface{}{
+		"message": map[string]interface{}{"dwellTimes": []interface{}{60.0, 75.0, 90.0}},
+	}}
+	if !keyboardOnlyUser(human, getMap(human, "behavioral")) {
+		t.Error("human field dwell must keep the exemption")
+	}
+}
+
+func TestKeyboardExemptionNeedsEnoughHoldsToJudge(t *testing.T) {
+	sig := keyboardSignals(4, map[string]interface{}{"keyHoldSamples": 2.0, "keyHoldAvg": 3.0})
+	if !keyboardOnlyUser(sig, getMap(sig, "behavioral")) {
+		t.Error("two holds are too few to take an exemption away on")
+	}
+}
+
+func TestKeyboardExemptionRequiresKeysAndNoPointer(t *testing.T) {
+	one := keyboardSignals(1, nil)
+	if keyboardOnlyUser(one, getMap(one, "behavioral")) {
+		t.Error("one key event is not keyboard use")
+	}
+	moved := keyboardSignals(8, map[string]interface{}{"totalPoints": 3.0})
+	if keyboardOnlyUser(moved, getMap(moved, "behavioral")) {
+		t.Error("a visitor who moved the pointer is not keyboard-only")
+	}
+}
+
+// End to end: a keyboard-driven agent is scored as pointerless — both movement
+// views fire and corroborate — while a keyboard-only person is not.
+func TestKeyboardAgentIsScoredAsPointerless(t *testing.T) {
+	e := NewScoringEngine("test-secret")
+	agent := keyboardSignals(14, map[string]interface{}{"keyHoldSamples": 14.0, "keyHoldAvg": 2.0})
+	dets := append(e.detectVisionAI(agent), e.detectBehavioral(agent)...)
+	if !hasReasonContaining(dets, "Zero mouse, touch, or keyboard events") {
+		t.Errorf("agent should lose the exemption and score as pointerless, got %+v", dets)
+	}
+	if !hasReasonContaining(dets, "No mouse movement detected before click") {
+		t.Errorf("agent should trip the vision_ai movement check, got %+v", dets)
+	}
+	if got := applyCorroborationFloor(0.1, dets); got < corroborationFloor {
+		t.Errorf("two movement views should corroborate to %v, got %v", corroborationFloor, got)
+	}
+
+	person := keyboardSignals(14, map[string]interface{}{"keyHoldSamples": 14.0, "keyHoldAvg": 80.0})
+	dets = append(e.detectVisionAI(person), e.detectBehavioral(person)...)
+	if hasReasonContaining(dets, "Zero mouse") || hasReasonContaining(dets, "No mouse movement") {
+		t.Errorf("a keyboard-only person must keep the exemption, got %+v", dets)
+	}
+}

--- a/server-go/scoring.go
+++ b/server-go/scoring.go
@@ -69,7 +69,8 @@ type VerificationResult struct {
 	CategoryScores map[string]float64
 	Recommendation string
 	// Reason explains a token withheld for something other than the score:
-	// "pow_not_satisfied" or "hostname_not_allowed". Empty otherwise. Without it
+	// "rate_limited", "pow_not_satisfied" or "hostname_not_allowed". Empty
+	// otherwise. Without it
 	// an integrator whose score is comfortably under the threshold has no way to
 	// tell why no token came back.
 	Reason string
@@ -627,6 +628,27 @@ func (e *ScoringEngine) verifyWithHeaders(signals map[string]interface{}, ip, si
 	detections = append(detections, e.detectFingerprint(signals, ip, siteKey)...)
 	detections = append(detections, e.detectRateAbuse(ip, siteKey)...)
 
+	// Per-device verification rate. A precondition, not evidence: the
+	// rate_limit category weighs 0.01, so the per-address detection above can
+	// never move a verdict, and an automated client that verifies once every
+	// few seconds from one page instance is refused a token here instead. Keyed
+	// on the widget instance as well as address and fingerprint so identical
+	// machines behind one NAT — a lab, an office — do not share a budget.
+	deviceRateExceeded := false
+	if instance := widgetInstance(signals); instance != "" {
+		deviceKey := "device:" + siteKey + ":" + ip + ":" + deviceFingerprint(signals) + ":" + instance
+		if exceeded, count := e.rateLimiter.Check(deviceKey, 60, deviceVerificationsPerMinute); exceeded {
+			deviceRateExceeded = true
+			detections = append(detections, DetectionResult{
+				Category:   CategoryRateLimit,
+				Score:      0.8,
+				Confidence: 0.9,
+				Reason:     "Verification rate exceeded for this device (per-minute)",
+				Details:    map[string]interface{}{"count": count, "window": 60},
+			})
+		}
+	}
+
 	// Network/infrastructure detectors
 	detections = append(detections, e.CheckIPReputation(ip)...)
 	detections = append(detections, e.CheckBrowserConsistency(userAgent, signals)...)
@@ -701,7 +723,7 @@ func (e *ScoringEngine) verifyWithHeaders(signals map[string]interface{}, ip, si
 	// who never completed the challenge. Gating here means no future reweighting
 	// can reopen the bypass, and it holds even if the dispositive floor is
 	// lowered or removed.
-	success := finalScore < 0.5 && hostnameAllowed && powSatisfied
+	success := finalScore < 0.5 && hostnameAllowed && powSatisfied && !deviceRateExceeded
 
 	// Name the failed precondition whenever one fails, not only when the score
 	// would otherwise have allowed. Gating it on the score made the PoW case
@@ -710,6 +732,9 @@ func (e *ScoringEngine) verifyWithHeaders(signals map[string]interface{}, ip, si
 	// explained.
 	withheldReason := ""
 	switch {
+	case deviceRateExceeded:
+		// First because it is the one the caller can act on: back off.
+		withheldReason = "rate_limited"
 	case !powSatisfied:
 		withheldReason = "pow_not_satisfied"
 	case !hostnameAllowed:
@@ -1078,9 +1103,8 @@ func (e *ScoringEngine) detectVisionAI(signals map[string]interface{}) []Detecti
 	totalPoints := getFloat(behavioral, "totalPoints")
 	trajectoryLen := getFloat(behavioral, "trajectoryLength")
 	approachPts := getFloat(behavioral, "approachPoints")
-	keyEventsAI := getFloat(behavioral, "keyEvents")
 	isTouchUser := isTouchModality(behavioral)
-	isKeyboardUser := keyEventsAI >= 2 && totalPoints == 0
+	isKeyboardUser := keyboardOnlyUser(signals, behavioral)
 	// Click-derived fields only exist when a widget was there to click.
 	isWidget := hasWidgetInteraction(signals)
 
@@ -1636,7 +1660,7 @@ func (e *ScoringEngine) detectBehavioral(signals map[string]interface{}) []Detec
 	trajectoryLength := getFloat(behavioral, "trajectoryLength")
 	keyEvents := getFloat(behavioral, "keyEvents")
 	isTouchUsr := isTouchModality(behavioral)
-	isKbdUsr := keyEvents >= 2 && totalPoints == 0
+	isKbdUsr := keyboardOnlyUser(signals, behavioral)
 	isWidget := hasWidgetInteraction(signals)
 
 	if totalPoints == 0 && !isTouchUsr && !isKbdUsr {
@@ -1925,17 +1949,7 @@ func (e *ScoringEngine) detectFingerprint(signals map[string]interface{}, ip, si
 	results := make([]DetectionResult, 0)
 
 	env := getMap(signals, "environmental")
-	automation := getMap(env, "automationFlags")
-
-	// Generate fingerprint
-	components := []string{
-		getString(env, "canvasHash"),
-		getString(getMap(env, "webglInfo"), "renderer"),
-		getString(automation, "platform"),
-		getString(automation, "hardwareConcurrency"),
-	}
-	fpHash := sha256.Sum256([]byte(strings.Join(components, "|")))
-	fingerprint := hex.EncodeToString(fpHash[:8])
+	fingerprint := deviceFingerprint(signals)
 
 	// Record fingerprint
 	e.fingerprintStore.Record(fingerprint, ip, siteKey)
@@ -1987,6 +2001,97 @@ func (e *ScoringEngine) detectFingerprint(signals map[string]interface{}, ip, si
 	}
 
 	return results
+}
+
+// deviceVerificationsPerMinute caps how many tokens one page instance on one
+// device at one address can be issued per minute. A person verifies a form
+// once and retries a handful of times; the automated client observed on the
+// public demo (2026-09-09) verified fourteen times in fifty-two seconds. Same
+// limit as the per-address detection so the two read consistently in logs.
+const deviceVerificationsPerMinute = 10
+
+// deviceFingerprint is the coarse device identity used for cardinality checks
+// and the per-device rate gate: canvas hash, WebGL renderer, platform and core
+// count. Identical hardware produces identical values, which is why the rate
+// gate also keys on the widget instance.
+func deviceFingerprint(signals map[string]interface{}) string {
+	env := getMap(signals, "environmental")
+	automation := getMap(env, "automationFlags")
+	components := []string{
+		getString(env, "canvasHash"),
+		getString(getMap(env, "webglInfo"), "renderer"),
+		getString(automation, "platform"),
+		getString(automation, "hardwareConcurrency"),
+	}
+	fpHash := sha256.Sum256([]byte(strings.Join(components, "|")))
+	return hex.EncodeToString(fpHash[:8])
+}
+
+// widgetInstance is the per-page-load id the widget or invisible session
+// reports about itself. Bounded, because it is client-supplied and becomes
+// part of a rate-limiter key.
+func widgetInstance(signals map[string]interface{}) string {
+	meta := getMap(signals, "meta")
+	id := getString(meta, "sessionId")
+	if id == "" {
+		id = getString(meta, "widgetId")
+	}
+	if len(id) > 64 {
+		id = id[:64]
+	}
+	return id
+}
+
+// Keyboard-only accessibility exemption.
+//
+// A visitor who works the page from the keyboard — a screen-reader user, a
+// switch-access user, anyone who never touches a pointer — produces key events
+// and no pointer samples, and must not be scored as "no mouse movement". An
+// agent typing through an automation protocol produces exactly the same
+// counts, which is how a keyboard-driven form filler claimed the exemption on
+// the public demo (2026-09-09) and was scored as a person.
+//
+// The counts cannot tell them apart; the key holds can. A finger on a key
+// holds it for tens of milliseconds (the bench's keyboard personas never drop
+// below 41ms); an automation protocol releases it in one or two. So the
+// exemption asks, when hold data exists, that it look like fingers. With no
+// hold data at all — a widget older than this check, or a visitor who only
+// tabbed to the checkbox and never typed into a field — the exemption stands,
+// because refusing it would score exactly the people it protects.
+const (
+	// machineKeyHoldMS is the average keydown→keyup hold below which the keys
+	// were not pressed by a hand: well under the 41ms bench floor, well over
+	// the 1–8ms an automation protocol produces. A real-human capture should
+	// confirm it before it is tightened.
+	machineKeyHoldMS = 20.0
+	// minKeyHoldSamples is how many holds the average has to rest on.
+	minKeyHoldSamples = 3.0
+)
+
+func keyboardOnlyUser(signals, behavioral map[string]interface{}) bool {
+	if getFloat(behavioral, "keyEvents") < 2 || getFloat(behavioral, "totalPoints") != 0 {
+		return false
+	}
+	return !mechanicalKeyHold(signals, behavioral)
+}
+
+// mechanicalKeyHold pools every key hold the client reported — the
+// session-level summary and the per-field dwell times from the form analyser
+// — and reports whether their average is too short for a hand.
+func mechanicalKeyHold(signals, behavioral map[string]interface{}) bool {
+	n := getFloat(behavioral, "keyHoldSamples")
+	sum := n * getFloat(behavioral, "keyHoldAvg")
+	for _, raw := range getMap(getMap(signals, "formAnalysis"), "textareaKeyboard") {
+		stats, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, d := range getFloatSlice(stats, "dwellTimes") {
+			n++
+			sum += d
+		}
+	}
+	return n >= minKeyHoldSamples && sum/n < machineKeyHoldMS
 }
 
 func (e *ScoringEngine) detectRateAbuse(ip, siteKey string) []DetectionResult {

--- a/server-node/device-rate.test.js
+++ b/server-node/device-rate.test.js
@@ -1,0 +1,47 @@
+'use strict';
+
+// The per-device verification rate gate: a precondition on token issuance, not
+// weighted evidence. Mirrors server-go/device_rate_test.go.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { createScoringEngine } = require('./index');
+const { widgetInstance, DEVICE_VERIFICATIONS_PER_MINUTE } = require('./engine');
+
+const signals = (instance) => ({
+  behavioral: { totalPoints: 60, trajectoryLength: 400, approachPoints: 12,
+    approachDirectness: 0.4, microTremorScore: 0.5, velocityVariance: 0.5 },
+  environmental: { automationFlags: {} },
+  ...(instance ? { meta: { sessionId: instance } } : {}),
+});
+const headers = { accept: 'text/html', 'accept-language': 'en-US' };
+
+test('the eleventh verification from one page instance is withheld as rate_limited', () => {
+  const engine = createScoringEngine({ secret: 'test-secret' });
+  for (let i = 0; i < DEVICE_VERIFICATIONS_PER_MINUTE; i++) {
+    const r = engine.verify(signals('page-a'), '203.0.113.77', 'site', 'ua', headers);
+    assert.notEqual(r.reason, 'rate_limited', `verification ${i + 1} was rate limited early`);
+  }
+  const r = engine.verify(signals('page-a'), '203.0.113.77', 'site', 'ua', headers);
+  assert.equal(r.success, false);
+  assert.equal(r.reason, 'rate_limited');
+  assert.ok(r.detections.some((d) => /for this device/.test(d.reason)));
+
+  // Another page instance on the same address and device has its own budget.
+  const other = engine.verify(signals('page-b'), '203.0.113.77', 'site', 'ua', headers);
+  assert.notEqual(other.reason, 'rate_limited');
+});
+
+test('no widget instance means no device gate', () => {
+  const engine = createScoringEngine({ secret: 'test-secret' });
+  for (let i = 0; i <= DEVICE_VERIFICATIONS_PER_MINUTE + 2; i++) {
+    const r = engine.verify(signals(''), '203.0.113.78', 'site', 'ua', headers);
+    assert.notEqual(r.reason, 'rate_limited');
+  }
+});
+
+test('the instance id is bounded before it becomes a key', () => {
+  assert.equal(widgetInstance({ meta: { widgetId: 'x'.repeat(500) } }).length, 64);
+  assert.equal(widgetInstance({}), '');
+  assert.equal(widgetInstance({ meta: { sessionId: 42 } }), '');
+});

--- a/server-node/engine.js
+++ b/server-node/engine.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const crypto = require('crypto');
+
 /**
  * Shared detection and scoring core.
  *
@@ -130,6 +132,90 @@ function setInteractionMode(signals, widget) {
  * Whether click-derived behavioural fields carry meaning for this request.
  * Absent context means widget mode — the long-standing behaviour.
  */
+// Caps how many tokens one page instance on one device at one address can be
+// issued per minute. A person verifies a form once and retries a handful of
+// times; the automated client observed on the public demo (2026-09-09) verified
+// fourteen times in fifty-two seconds. Same limit as the per-address detection
+// so the two read consistently in logs.
+const DEVICE_VERIFICATIONS_PER_MINUTE = 10;
+
+const nested = (o, ...keys) => keys.reduce((v, k) => (v && typeof v === 'object') ? v[k] : undefined, o);
+
+// Coarse device identity used for cardinality checks and the per-device rate
+// gate: canvas hash, WebGL renderer, platform and core count. Identical
+// hardware produces identical values, which is why the rate gate also keys on
+// the widget instance.
+function deviceFingerprint(signals) {
+  const env = (signals && signals.environmental) || {};
+  const automation = env.automationFlags || {};
+  const components = [
+    String(nested(env, 'canvasHash', 'hash') || ''),
+    String(nested(env, 'webglInfo', 'renderer') || ''),
+    String(automation.platform || ''),
+    String(automation.hardwareConcurrency || '')
+  ];
+  return crypto.createHash('sha256').update(components.join('|')).digest('hex').slice(0, 16);
+}
+
+// The per-page-load id the widget or invisible session reports about itself.
+// Bounded, because it is client-supplied and becomes part of a rate-limiter key.
+function widgetInstance(signals) {
+  const meta = (signals && signals.meta) || {};
+  const id = typeof meta.sessionId === 'string' && meta.sessionId ? meta.sessionId
+    : typeof meta.widgetId === 'string' ? meta.widgetId : '';
+  return id.slice(0, 64);
+}
+
+// The rate gate as one function so server.js and index.js cannot drift.
+// Returns the detection to record when the budget is exhausted, else null.
+function deviceRateDetection(exceeded, count) {
+  if (!exceeded) return null;
+  return { category: 'rate_limit', score: 0.8, confidence: 0.9,
+    reason: 'Verification rate exceeded for this device (per-minute)', details: { count, window: 60 } };
+}
+const deviceRateKey = (siteKey, ip, signals, instance) => `device:${siteKey}:${ip}:${deviceFingerprint(signals)}:${instance}`;
+
+/**
+ * Keyboard-only accessibility exemption.
+ *
+ * A visitor who works the page from the keyboard — a screen-reader user, a
+ * switch-access user, anyone who never touches a pointer — produces key events
+ * and no pointer samples, and must not be scored as "no mouse movement". An
+ * agent typing through an automation protocol produces exactly the same counts,
+ * which is how a keyboard-driven form filler claimed the exemption on the public
+ * demo (2026-09-09) and was scored as a person.
+ *
+ * The counts cannot tell them apart; the key holds can. A finger on a key holds
+ * it for tens of milliseconds (the bench's keyboard personas never drop below
+ * 41ms); an automation protocol releases it in one or two. So the exemption
+ * asks, when hold data exists, that it look like fingers. With no hold data at
+ * all — a widget older than this check, or a visitor who only tabbed to the
+ * checkbox and never typed into a field — the exemption stands, because refusing
+ * it would score exactly the people it protects.
+ */
+// Average keydown→keyup hold below which the keys were not pressed by a hand:
+// well under the 41ms bench floor, well over the 1–8ms an automation protocol
+// produces. A real-human capture should confirm it before it is tightened.
+const MACHINE_KEY_HOLD_MS = 20;
+// How many holds the average has to rest on.
+const MIN_KEY_HOLD_SAMPLES = 3;
+
+function mechanicalKeyHold(signals, b) {
+  let n = Number(b.keyHoldSamples) || 0;
+  let sum = n * (Number(b.keyHoldAvg) || 0);
+  const fields = nested(signals, 'formAnalysis', 'textareaKeyboard') || {};
+  for (const stats of Object.values(fields)) {
+    const dwells = stats && Array.isArray(stats.dwellTimes) ? stats.dwellTimes : [];
+    for (const d of dwells) { if (typeof d === 'number') { n++; sum += d; } }
+  }
+  return n >= MIN_KEY_HOLD_SAMPLES && sum / n < MACHINE_KEY_HOLD_MS;
+}
+
+function keyboardOnlyUser(signals, b) {
+  if ((b.keyEvents ?? 0) < 2 || (b.totalPoints ?? 0) !== 0) return false;
+  return !mechanicalKeyHold(signals, b);
+}
+
 function hasWidgetInteraction(signals) {
   const ctx = signals && signals[SERVER_CONTEXT_KEY];
   if (!ctx || typeof ctx.widgetInteraction !== 'boolean') return true;
@@ -149,7 +235,7 @@ function detectVisionAI(signals) {
   const touchEvents = b.touchEvents ?? 0;
   const keyEvents = b.keyEvents ?? 0;
   const isTouchUser = isTouchModality(b);
-  const isKeyboardUser = keyEvents >= 2 && totalPoints === 0;
+  const isKeyboardUser = keyboardOnlyUser(signals, b);
   // Click-derived fields only exist when a widget was there to click.
   const isWidget = hasWidgetInteraction(signals);
 
@@ -550,7 +636,7 @@ function detectBehavioral(signals) {
   const touchEvts = b.touchEvents ?? 0;
   const keyEvts = b.keyEvents ?? 0;
   const isTouchUsr = isTouchModality(b);
-  const isKbdUser = keyEvts >= 2 && totalPoints === 0;
+  const isKbdUser = keyboardOnlyUser(signals, b);
 
   if (totalPoints === 0 && !isTouchUsr && !isKbdUser) {
     detections.push({
@@ -961,6 +1047,15 @@ function applyCorroborationFloor(score, detections) {
 
 module.exports = {
   // Constants
+  DEVICE_VERIFICATIONS_PER_MINUTE,
+  MACHINE_KEY_HOLD_MS,
+  MIN_KEY_HOLD_SAMPLES,
+  deviceFingerprint,
+  widgetInstance,
+  deviceRateKey,
+  deviceRateDetection,
+  keyboardOnlyUser,
+  mechanicalKeyHold,
   AUTOMATION_UA_PATTERNS,
   WEIGHTS,
   DISPOSITIVE_FLOOR,

--- a/server-node/index.js
+++ b/server-node/index.js
@@ -187,6 +187,7 @@ const {
   calculateFinalScore,
   applyDispositiveFloor,
   applyCorroborationFloor,
+  widgetInstance, deviceRateKey, deviceRateDetection, DEVICE_VERIFICATIONS_PER_MINUTE
 } = require('./engine');
 const { detectInputForensics } = require('./inputforensics');
 
@@ -342,6 +343,17 @@ class ScoringEngine {
     // Calculate scores
     // Same aggregation as server.js: noisy-OR within a category, weighted sum
     // across them, then the dispositive and corroboration floors.
+    // Per-device verification rate — a precondition, not evidence. Keyed on the
+    // widget instance too, so identical machines behind one NAT do not share a
+    // budget. See DEVICE_VERIFICATIONS_PER_MINUTE in engine.js.
+    let deviceRateExceeded = false;
+    const instance = widgetInstance(signals);
+    if (instance) {
+      const [exceeded, count] = this.rateLimiter.check(deviceRateKey(siteKey, ip, signals, instance), 60, DEVICE_VERIFICATIONS_PER_MINUTE);
+      const hit = deviceRateDetection(exceeded, count);
+      if (hit) { deviceRateExceeded = true; detections.push(hit); }
+    }
+
     const categoryScores = calculateCategoryScores(detections, this.weights);
     const finalScore = applyCorroborationFloor(
       applyDispositiveFloor(calculateFinalScore(categoryScores, this.weights), detections),
@@ -358,7 +370,7 @@ class ScoringEngine {
     // dilute it below the allow threshold and used to mint a token for an empty
     // request. Keep this gate independent of scoring so weight changes cannot
     // reopen the bypass.
-    const success = finalScore < 0.5 && powSatisfied;
+    const success = finalScore < 0.5 && powSatisfied && !deviceRateExceeded;
     const token = success ? this._generateToken(ip, siteKey, finalScore) : null;
 
     // Feed the ledger so the next challenge this source asks for is priced on
@@ -373,7 +385,7 @@ class ScoringEngine {
       recommendation,
       categoryScores,
       detections,
-      ...(!powSatisfied ? { reason: 'pow_not_satisfied' } : {})
+      ...(deviceRateExceeded ? { reason: 'rate_limited' } : !powSatisfied ? { reason: 'pow_not_satisfied' } : {})
     };
   }
 

--- a/server-node/keyboard-exemption.test.js
+++ b/server-node/keyboard-exemption.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+// The keyboard-only accessibility exemption and the key-hold check that keeps a
+// keyboard-driven agent from claiming it. Mirrors server-go/keyboard_exemption_test.go.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  keyboardOnlyUser, detectVisionAI, detectBehavioral, applyCorroborationFloor, CORROBORATION_FLOOR,
+} = require('./engine');
+
+const kb = (keyEvents, extra = {}) => ({
+  behavioral: { totalPoints: 0, trajectoryLength: 0, keyEvents, touchEvents: 0, ...extra },
+  environmental: { automationFlags: {} },
+});
+const reasons = (dets) => dets.map((d) => d.reason).join(' | ');
+
+test('the exemption stands without hold data', () => {
+  const s = kb(8);
+  assert.equal(keyboardOnlyUser(s, s.behavioral), true);
+});
+
+test('the exemption stands for fingers', () => {
+  const s = kb(12, { keyHoldSamples: 6, keyHoldAvg: 85 });
+  assert.equal(keyboardOnlyUser(s, s.behavioral), true);
+});
+
+test('the exemption is denied for mechanical holds', () => {
+  const s = kb(12, { keyHoldSamples: 6, keyHoldAvg: 4 });
+  assert.equal(keyboardOnlyUser(s, s.behavioral), false);
+});
+
+test('form-field dwell times are pooled into the judgement', () => {
+  const mechanical = { ...kb(9), formAnalysis: { textareaKeyboard: { message: { dwellTimes: [2, 3, 1, 2] } } } };
+  assert.equal(keyboardOnlyUser(mechanical, mechanical.behavioral), false);
+  const human = { ...kb(9), formAnalysis: { textareaKeyboard: { message: { dwellTimes: [60, 75, 90] } } } };
+  assert.equal(keyboardOnlyUser(human, human.behavioral), true);
+});
+
+test('too few holds cannot take the exemption away', () => {
+  const s = kb(4, { keyHoldSamples: 2, keyHoldAvg: 3 });
+  assert.equal(keyboardOnlyUser(s, s.behavioral), true);
+});
+
+test('the exemption requires key events and no pointer', () => {
+  const one = kb(1);
+  assert.equal(keyboardOnlyUser(one, one.behavioral), false);
+  const moved = kb(8, { totalPoints: 3 });
+  assert.equal(keyboardOnlyUser(moved, moved.behavioral), false);
+});
+
+test('a keyboard-driven agent is scored as pointerless and corroborates; a keyboard person is not', () => {
+  const agent = kb(14, { keyHoldSamples: 14, keyHoldAvg: 2 });
+  let dets = [...detectVisionAI(agent), ...detectBehavioral(agent)];
+  assert.match(reasons(dets), /Zero mouse, touch, or keyboard events/);
+  assert.match(reasons(dets), /No mouse movement detected before click/);
+  assert.ok(applyCorroborationFloor(0.1, dets) >= CORROBORATION_FLOOR);
+
+  const person = kb(14, { keyHoldSamples: 14, keyHoldAvg: 80 });
+  dets = [...detectVisionAI(person), ...detectBehavioral(person)];
+  assert.doesNotMatch(reasons(dets), /Zero mouse|No mouse movement/);
+});

--- a/server-node/package.json
+++ b/server-node/package.json
@@ -15,7 +15,7 @@
     "test:clientip": "node clientip.test.js",
     "test:limits": "node limits.test.js",
     "test:detection": "node detection.test.js",
-    "test": "node version.test.js && node config.test.js && node clientip.test.js && node limits.test.js && node detection.test.js && node inputforensics.test.js && node interactionmode.test.js && node exemptions.test.js && node webbotauth.test.js && node siteverify.test.js && node redis-state.test.js && node index.test.js && node --test suspicion.test.js security.test.js corroboration.test.js",
+    "test": "node version.test.js && node config.test.js && node clientip.test.js && node limits.test.js && node detection.test.js && node inputforensics.test.js && node interactionmode.test.js && node exemptions.test.js && node webbotauth.test.js && node siteverify.test.js && node redis-state.test.js && node index.test.js && node --test suspicion.test.js security.test.js corroboration.test.js device-rate.test.js keyboard-exemption.test.js",
     "test:siteverify": "node siteverify.test.js",
     "test:forensics": "node inputforensics.test.js",
     "test:suspicion": "node --test suspicion.test.js"

--- a/server-node/server.js
+++ b/server-node/server.js
@@ -369,6 +369,7 @@ const {
   calculateFinalScore,
   applyDispositiveFloor,
   applyCorroborationFloor,
+  widgetInstance, deviceRateKey, deviceRateDetection, DEVICE_VERIFICATIONS_PER_MINUTE
 } = require('./engine');
 
 // Stateful detectors stay here: they read the module-level stores below.
@@ -675,6 +676,18 @@ async function runVerification(signals, ip, siteKey, userAgent, headers = {}, ja
   detections.push(...await detectFingerprint(signals, ip, siteKey));
   detections.push(...await detectRateAbuse(ip, siteKey));
 
+  // Per-device verification rate — a precondition, not evidence: rate_limit
+  // weighs 0.01, so the per-address detection above can never move a verdict.
+  // Keyed on the widget instance too, so identical machines behind one NAT do
+  // not share a budget. See DEVICE_VERIFICATIONS_PER_MINUTE in engine.js.
+  let deviceRateExceeded = false;
+  const instance = widgetInstance(signals);
+  if (instance) {
+    const [exceeded, count] = await rateLimiter.check(deviceRateKey(siteKey, ip, signals, instance), 60, DEVICE_VERIFICATIONS_PER_MINUTE);
+    const hit = deviceRateDetection(exceeded, count);
+    if (hit) { deviceRateExceeded = true; detections.push(hit); }
+  }
+
   // Add IP reputation check (async but we'll use sync version for simplicity)
   if (detection.isDatacenterIP(ip)) {
     detections.push({
@@ -754,7 +767,7 @@ async function runVerification(signals, ip, siteKey, userAgent, headers = {}, ja
   // who never completed the challenge. Gating here means no future reweighting
   // can reopen the bypass, and it holds even if the dispositive floor is
   // lowered or removed.
-  const success = finalScore < 0.5 && hostnameAllowed && powSatisfied;
+  const success = finalScore < 0.5 && hostnameAllowed && powSatisfied && !deviceRateExceeded;
 
   // Name the failed precondition whenever one fails, not only when the score
   // would otherwise have allowed. Gating it on the score made the PoW case
@@ -762,7 +775,9 @@ async function runVerification(signals, ip, siteKey, userAgent, headers = {}, ja
   // and the branch never fired — which is exactly the case a caller most needs
   // explained.
   let withheldReason = '';
-  if (!powSatisfied) withheldReason = 'pow_not_satisfied';
+  // Rate first because it is the one the caller can act on: back off.
+  if (deviceRateExceeded) withheldReason = 'rate_limited';
+  else if (!powSatisfied) withheldReason = 'pow_not_satisfied';
   else if (!hostnameAllowed) withheldReason = 'hostname_not_allowed';
 
   const token = success

--- a/server-python/server.py
+++ b/server-python/server.py
@@ -770,6 +770,87 @@ def has_widget_interaction(signals: Dict) -> bool:
     return True
 
 
+# Caps how many tokens one page instance on one device at one address can be
+# issued per minute. A person verifies a form once and retries a handful of
+# times; the automated client observed on the public demo (2026-09-09) verified
+# fourteen times in fifty-two seconds. Same limit as the per-address detection
+# so the two read consistently in logs.
+DEVICE_VERIFICATIONS_PER_MINUTE = 10
+
+
+def device_fingerprint(signals: Dict) -> str:
+    """Coarse device identity used for cardinality checks and the per-device
+    rate gate: canvas hash, WebGL renderer, platform and core count. Identical
+    hardware produces identical values, which is why the rate gate also keys on
+    the widget instance."""
+    env = signals.get("environmental") or {}
+    automation = env.get("automationFlags") or {}
+    components = [
+        str(get_nested(env, "canvasHash", "hash", default="")),
+        str(get_nested(env, "webglInfo", "renderer", default="")),
+        str(automation.get("platform", "")),
+        str(automation.get("hardwareConcurrency", "")),
+    ]
+    return hashlib.sha256("|".join(components).encode()).hexdigest()[:16]
+
+
+def widget_instance(signals: Dict) -> str:
+    """The per-page-load id the widget or invisible session reports about
+    itself. Bounded, because it is client-supplied and becomes part of a
+    rate-limiter key."""
+    meta = signals.get("meta") or {}
+    ident = meta.get("sessionId") or meta.get("widgetId") or ""
+    return ident[:64] if isinstance(ident, str) else ""
+
+
+def device_rate_key(site_key: str, ip: str, signals: Dict, instance: str) -> str:
+    return f"device:{site_key}:{ip}:{device_fingerprint(signals)}:{instance}"
+
+
+# Keyboard-only accessibility exemption.
+#
+# A visitor who works the page from the keyboard - a screen-reader user, a
+# switch-access user, anyone who never touches a pointer - produces key events
+# and no pointer samples, and must not be scored as "no mouse movement". An
+# agent typing through an automation protocol produces exactly the same counts,
+# which is how a keyboard-driven form filler claimed the exemption on the public
+# demo (2026-09-09) and was scored as a person.
+#
+# The counts cannot tell them apart; the key holds can. A finger on a key holds
+# it for tens of milliseconds (the bench's keyboard personas never drop below
+# 41ms); an automation protocol releases it in one or two. So the exemption
+# asks, when hold data exists, that it look like fingers. With no hold data at
+# all - a widget older than this check, or a visitor who only tabbed to the
+# checkbox and never typed into a field - the exemption stands, because refusing
+# it would score exactly the people it protects.
+#
+# Average keydown->keyup hold below which the keys were not pressed by a hand:
+# well under the 41ms bench floor, well over the 1-8ms an automation protocol
+# produces. A real-human capture should confirm it before it is tightened.
+MACHINE_KEY_HOLD_MS = 20.0
+# How many holds the average has to rest on.
+MIN_KEY_HOLD_SAMPLES = 3
+
+
+def mechanical_key_hold(signals: Dict, b: Dict) -> bool:
+    n = float(b.get("keyHoldSamples") or 0)
+    total = n * float(b.get("keyHoldAvg") or 0)
+    fields = get_nested(signals, "formAnalysis", "textareaKeyboard", default=None) or {}
+    for stats in fields.values() if isinstance(fields, dict) else []:
+        dwells = stats.get("dwellTimes") if isinstance(stats, dict) else None
+        for d in dwells or []:
+            if isinstance(d, (int, float)):
+                n += 1
+                total += d
+    return n >= MIN_KEY_HOLD_SAMPLES and total / n < MACHINE_KEY_HOLD_MS
+
+
+def keyboard_only_user(signals: Dict, b: Dict) -> bool:
+    if b.get("keyEvents", 0) < 2 or b.get("totalPoints", 0) != 0:
+        return False
+    return not mechanical_key_hold(signals, b)
+
+
 def detect_vision_ai(signals: Dict) -> List[Detection]:
     detections = []
     b = signals.get("behavioral", {})
@@ -783,7 +864,7 @@ def detect_vision_ai(signals: Dict) -> List[Detection]:
     touch_events = b.get("touchEvents", 0)
     key_events = b.get("keyEvents", 0)
     is_touch_user = _is_touch_modality(b)
-    is_keyboard_user = key_events >= 2 and total_points == 0
+    is_keyboard_user = keyboard_only_user(signals, b)
     # Click-derived fields only exist when a widget was there to click.
     is_widget = has_widget_interaction(signals)
 
@@ -1157,7 +1238,7 @@ def detect_behavioral(signals: Dict) -> List[Detection]:
     touch_events = b.get("touchEvents", 0)
     key_events = b.get("keyEvents", 0)
     is_touch_user = _is_touch_modality(b)
-    is_keyboard_user = key_events >= 2 and total_points == 0
+    is_keyboard_user = keyboard_only_user(signals, b)
 
     if total_points == 0 and not is_touch_user and not is_keyboard_user:
         detections.append(Detection(
@@ -1868,6 +1949,23 @@ def run_verification(
     detections.extend(detect_fingerprint(signals, ip, site_key))
     detections.extend(detect_rate_abuse(ip, site_key))
 
+    # Per-device verification rate - a precondition, not evidence: rate_limit
+    # weighs 0.01, so the per-address detection above can never move a verdict.
+    # Keyed on the widget instance too, so identical machines behind one NAT do
+    # not share a budget. See DEVICE_VERIFICATIONS_PER_MINUTE.
+    device_rate_exceeded = False
+    instance = widget_instance(signals)
+    if instance:
+        exceeded, count = rate_limiter.check(
+            device_rate_key(site_key, ip, signals, instance), 60, DEVICE_VERIFICATIONS_PER_MINUTE)
+        if exceeded:
+            device_rate_exceeded = True
+            detections.append(Detection(
+                ThreatCategory.RATE_LIMIT, 0.8, 0.9,
+                "Verification rate exceeded for this device (per-minute)",
+                {"count": count, "window": 60},
+            ))
+
     # Network/infrastructure detectors
     for d in check_ip_reputation(ip):
         detections.append(Detection(
@@ -1961,7 +2059,7 @@ def run_verification(
     # who never completed the challenge. Gating here means no future reweighting
     # can reopen the bypass, and it holds even if the dispositive floor is
     # lowered or removed.
-    success = final_score < 0.5 and hostname_allowed and pow_satisfied
+    success = final_score < 0.5 and hostname_allowed and pow_satisfied and not device_rate_exceeded
 
     # Name the failed precondition whenever one fails, not only when the score
     # would otherwise have allowed. Gating it on the score made the PoW case
@@ -1969,7 +2067,10 @@ def run_verification(
     # and the branch never fired - which is exactly the case a caller most needs
     # explained.
     withheld_reason = ""
-    if not pow_satisfied:
+    # Rate first because it is the one the caller can act on: back off.
+    if device_rate_exceeded:
+        withheld_reason = "rate_limited"
+    elif not pow_satisfied:
         withheld_reason = "pow_not_satisfied"
     elif not hostname_allowed:
         withheld_reason = "hostname_not_allowed"

--- a/server-python/test_detection.py
+++ b/server-python/test_detection.py
@@ -28,6 +28,9 @@ from server import (
     BEHAVIOURAL_CATEGORIES,
     CORROBORATION_AGREE_AT,
     CORROBORATION_FLOOR,
+    keyboard_only_user,
+    widget_instance,
+    DEVICE_VERIFICATIONS_PER_MINUTE,
 )
 
 test = TestRegistry()
@@ -331,6 +334,108 @@ def a_developer_with_devtools_open_and_a_quick_click_is_not_floored():
         Detection(ThreatCategory.FINGERPRINT, 0.4, 0.4, "canvas blocked"),
     ]
     assert apply_corroboration_floor(0.115, dets) == 0.115
+
+
+# ---------------------------------------------------------------------------
+# Keyboard-only exemption and the per-device rate gate. Mirror the Go tests.
+# ---------------------------------------------------------------------------
+
+def kb(key_events, **extra):
+    b = {"totalPoints": 0, "trajectoryLength": 0, "keyEvents": key_events, "touchEvents": 0}
+    b.update(extra)
+    return {"behavioral": b, "environmental": {"automationFlags": {}}}
+
+
+def reasons(dets):
+    return " | ".join(d.reason for d in dets)
+
+
+@test
+def keyboard_exemption_stands_without_hold_data():
+    s = kb(8)
+    assert keyboard_only_user(s, s["behavioral"]) is True
+
+
+@test
+def keyboard_exemption_stands_for_fingers():
+    s = kb(12, keyHoldSamples=6, keyHoldAvg=85)
+    assert keyboard_only_user(s, s["behavioral"]) is True
+
+
+@test
+def keyboard_exemption_denied_for_mechanical_holds():
+    s = kb(12, keyHoldSamples=6, keyHoldAvg=4)
+    assert keyboard_only_user(s, s["behavioral"]) is False
+
+
+@test
+def keyboard_exemption_pools_form_field_dwell():
+    mechanical = dict(kb(9), formAnalysis={"textareaKeyboard": {"message": {"dwellTimes": [2, 3, 1, 2]}}})
+    assert keyboard_only_user(mechanical, mechanical["behavioral"]) is False
+    human = dict(kb(9), formAnalysis={"textareaKeyboard": {"message": {"dwellTimes": [60, 75, 90]}}})
+    assert keyboard_only_user(human, human["behavioral"]) is True
+
+
+@test
+def keyboard_exemption_needs_enough_holds_to_judge():
+    s = kb(4, keyHoldSamples=2, keyHoldAvg=3)
+    assert keyboard_only_user(s, s["behavioral"]) is True
+
+
+@test
+def keyboard_exemption_requires_keys_and_no_pointer():
+    one = kb(1)
+    assert keyboard_only_user(one, one["behavioral"]) is False
+    moved = kb(8, totalPoints=3)
+    assert keyboard_only_user(moved, moved["behavioral"]) is False
+
+
+@test
+def keyboard_agent_is_scored_as_pointerless_and_corroborates():
+    agent = kb(14, keyHoldSamples=14, keyHoldAvg=2)
+    dets = detect_vision_ai(agent) + detect_behavioral(agent)
+    assert "Zero mouse, touch, or keyboard events" in reasons(dets), reasons(dets)
+    assert "No mouse movement detected before click" in reasons(dets), reasons(dets)
+    assert apply_corroboration_floor(0.1, dets) >= CORROBORATION_FLOOR
+    person = kb(14, keyHoldSamples=14, keyHoldAvg=80)
+    dets = detect_vision_ai(person) + detect_behavioral(person)
+    assert "Zero mouse" not in reasons(dets) and "No mouse movement" not in reasons(dets), reasons(dets)
+
+
+def device_signals(instance):
+    s = {"behavioral": {"totalPoints": 60, "trajectoryLength": 400, "approachPoints": 12,
+                        "approachDirectness": 0.4, "microTremorScore": 0.5, "velocityVariance": 0.5},
+         "environmental": {"automationFlags": {}}}
+    if instance:
+        s["meta"] = {"sessionId": instance}
+    return s
+
+
+@test
+def the_eleventh_verification_from_one_page_instance_is_withheld():
+    ip = "198.51.100.77"
+    for i in range(DEVICE_VERIFICATIONS_PER_MINUTE):
+        r = run_verification(device_signals("page-a"), ip, "site", "ua")
+        assert r.get("reason") != "rate_limited", f"verification {i + 1} rate limited early"
+    r = run_verification(device_signals("page-a"), ip, "site", "ua")
+    assert r["success"] is False and r.get("reason") == "rate_limited", r
+    assert any("for this device" in d["reason"] for d in r["detections"]), r["detections"]
+    other = run_verification(device_signals("page-b"), ip, "site", "ua")
+    assert other.get("reason") != "rate_limited", "a different widget instance must not inherit the budget"
+
+
+@test
+def no_widget_instance_means_no_device_gate():
+    for _ in range(DEVICE_VERIFICATIONS_PER_MINUTE + 3):
+        r = run_verification(device_signals(""), "198.51.100.78", "site", "ua")
+        assert r.get("reason") != "rate_limited"
+
+
+@test
+def the_instance_id_is_bounded_before_it_becomes_a_key():
+    assert len(widget_instance({"meta": {"widgetId": "x" * 500}})) == 64
+    assert widget_instance({}) == ""
+    assert widget_instance({"meta": {"sessionId": 42}}) == ""
 
 
 DetectionTests = test.testcase("DetectionTests")


### PR DESCRIPTION
## What and why

An automated client was observed on the public demo verifying invisible mode every few seconds and receiving a token each time. Two things let it through: the keyboard-only accessibility exemption accepted key events with no pointer as proof of a keyboard user, and the per-minute rate limit only produced a detection in a category that carries almost no weight.

- **Per-device verification rate gate.** After 10 verifications in a minute from one page instance on one device at one address, the token is withheld with `reason: rate_limited`. Keyed on the widget instance as well as address and fingerprint, so identical machines behind one address do not share a budget. A client that reports no instance id is not gated. Applied to Go, Node, and Python.
- **Keyboard exemption checks key holds.** When hold data is present, at least three holds averaging under 20ms deny the exemption, and the session is scored as pointerless. No hold data keeps the exemption, so older widgets and visitors who only tab to the checkbox are unaffected. The widget now reports an average key hold alongside its key count; durations only, never which key.
- **Bench capture** now holds keys with a human-like delay for the keyboard-only and screen-reader personas, so a future re-capture does not score the harness's own humans as agents.

## Validation

- `run-bench.js --gate`: human FPR 0.00% (0/126), agent TPR 97.33%, PASS.
- Go vet and test, Node and Python suites pass, with ten new tests per server covering the exemption boundaries and the rate gate.
- Playwright accessibility, lifecycle, and PoW specs pass with the new widget.
- E2E detection suite passes against the Node server.

## Compatibility

- Integrators see a new withheld reason, `rate_limited`, documented in the README.
- Sessions with mechanical key holds and no pointer now score as pointerless and can block.
- The device fingerprint the gate uses differs between Go and Node (canvas hash field shape), which predates this change; under mixed-runtime Redis the per-device budget is counted per runtime.

## Follow-up

- Bench runs on macOS must be caffeinated; documented in bench/README.md.
- The 20ms hold threshold is set well below the panel's 41ms floor and well above automation's 1 to 8ms; a real-human capture should confirm it before it is tightened.

https://claude.ai/code/session_0198hVg9KALKecyEFDhsDxdg
